### PR TITLE
chore: do not run prep automatically

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -45,4 +45,4 @@ runs:
 
     - name: Install dependencies
       shell: bash
-      run: pnpm install
+      run: pnpm i

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,9 @@ jobs:
           server-token: "local"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Prepare packages
+        run: pnpm prep
+
       - name: Test
         run: pnpm test
         env:

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@
 Just run:
 
 ```
-pnpm install && pnpm build
+pnpm i && pnpm prep
 ```
 
-This should install all the needed files and a fully working application.
+This should install all the needed files and prepare applications and packages.
 
 ## CMS run
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "commit": "git-cz",
     "test": "turbo test:integration --output-logs=new-only --concurrency=1",
     "test:quick": "turbo test:static --output-logs=errors-only && turbo test:unit --output-logs=errors-only",
-    "prepare": "turbo prep --output-logs=new-only"
+    "prep": "turbo prep --output-logs=new-only"
   },
   "private": true,
   "optionalDependencies": {


### PR DESCRIPTION
## Motivation and context

- less magic
- turbo caching will work for `prep` in CI (currently it does not because `prep` is executed before the local turbo server is started)

## How has this been tested?

- [x] Manually
- [ ] Unit tests
- [x] Integration tests