### PR TITLE
chore: less noise in content export

### DIFF
--- a/apps/cms/composer.json
+++ b/apps/cms/composer.json
@@ -73,6 +73,11 @@
     }
   },
   "extra": {
+    "patches": {
+      "drupal/default_content": {
+        "#3181075 Allow to alter exported fields": "https://www.drupal.org/files/issues/2022-11-07/default_content_hook_exported_fields-3181075-7.patch"
+      }
+    },
     "patchLevel": {
       "drupal/core": "-p2"
     },

--- a/apps/cms/config/sync/core.extension.yml
+++ b/apps/cms/config/sync/core.extension.yml
@@ -10,6 +10,7 @@ module:
   config_pages: 0
   config_translation: 0
   content_moderation: 0
+  custom: 0
   datetime: 0
   datetime_range: 0
   dblog: 0

--- a/apps/cms/package.json
+++ b/apps/cms/package.json
@@ -8,8 +8,9 @@
   "sideEffects": false,
   "scripts": {
     "prep": "if command -v composer; then composer install; else echo 'Skipping composer install.'; fi",
-    "build": "pnpm drupal-install && rm -rf install-cache.zip && pnpm content:import && pnpm build:directives && pnpm fix-premissions && pnpm ensure-working-db",
+    "build": "pnpm drupal-install && rm -rf install-cache.zip && pnpm content:import && pnpm build:directives && pnpm export:schema && pnpm fix-premissions && pnpm ensure-working-db",
     "build:directives": "pnpm --silent drush graphql:directives > ../../packages/schema/src/generated/directives.graphqls",
+    "export:schema": "pnpm drush silverback-gatsby:schema-export ../../../tests/schema",
     "fix-premissions": "chmod +w web/sites/default/files/.htaccess && chmod +w web/sites/default/files/private/.htaccess",
     "ensure-working-db": "pnpm drush sqlq 'select * from node'",
     "drush": "SB_ENVIRONMENT=1 SIMPLETEST_DB=sqlite://localhost/sites/default/files/.sqlite DRUSH_OPTIONS_URI=http://127.0.0.1:8888 vendor/bin/drush",

--- a/packages/drupal/custom/custom.info.yml
+++ b/packages/drupal/custom/custom.info.yml
@@ -1,0 +1,4 @@
+name: Various customizations
+package: Custom
+type: module
+core_version_requirement: ^9.0 || ^10.0

--- a/packages/drupal/custom/custom.module
+++ b/packages/drupal/custom/custom.module
@@ -1,0 +1,22 @@
+<?php
+
+use Drupal\Core\Entity\ContentEntityInterface;
+
+/**
+ * Implements hook_default_content_exported_fields_alter().
+ */
+function custom_default_content_exported_fields_alter(array &$fields, ContentEntityInterface $entity) {
+
+  // These change randomly and bring no value.
+  unset(
+    $fields['metatag'],
+    $fields['external_preview_link'],
+  );
+
+  // If pathauto is enabled, content export may lose the path aliases.
+  if (isset($fields['path'])) {
+    if ($fields['path']->pathauto == 1) {
+      $fields['path']->pathauto = 0;
+    }
+  }
+}

--- a/packages/drupal/test_content/content/menu_link_content/1419f565-c610-406d-af5f-64a835e55ae9.yml
+++ b/packages/drupal/test_content/content/menu_link_content/1419f565-c610-406d-af5f-64a835e55ae9.yml
@@ -42,6 +42,12 @@ default:
   content_translation_outdated:
     -
       value: false
+  content_translation_uid:
+    -
+      target_id: 1
   content_translation_status:
     -
       value: true
+  content_translation_created:
+    -
+      value: 1681809202

--- a/packages/drupal/test_content/content/menu_link_content/2f5320ac-44ec-406a-83f4-66092c47f570.yml
+++ b/packages/drupal/test_content/content/menu_link_content/2f5320ac-44ec-406a-83f4-66092c47f570.yml
@@ -46,6 +46,12 @@ default:
   content_translation_outdated:
     -
       value: false
+  content_translation_uid:
+    -
+      target_id: 1
   content_translation_status:
     -
       value: true
+  content_translation_created:
+    -
+      value: 1681809202

--- a/packages/drupal/test_content/content/menu_link_content/3c354974-4c65-4849-b723-811ce9713a98.yml
+++ b/packages/drupal/test_content/content/menu_link_content/3c354974-4c65-4849-b723-811ce9713a98.yml
@@ -46,6 +46,12 @@ default:
   content_translation_outdated:
     -
       value: false
+  content_translation_uid:
+    -
+      target_id: 1
   content_translation_status:
     -
       value: true
+  content_translation_created:
+    -
+      value: 1681809202

--- a/packages/drupal/test_content/content/menu_link_content/809abec6-e8cf-4f50-b622-63d658d762ef.yml
+++ b/packages/drupal/test_content/content/menu_link_content/809abec6-e8cf-4f50-b622-63d658d762ef.yml
@@ -46,6 +46,12 @@ default:
   content_translation_outdated:
     -
       value: false
+  content_translation_uid:
+    -
+      target_id: 1
   content_translation_status:
     -
       value: true
+  content_translation_created:
+    -
+      value: 1681809202

--- a/packages/drupal/test_content/content/menu_link_content/b67c829d-212a-4e75-8813-3136fe29ff12.yml
+++ b/packages/drupal/test_content/content/menu_link_content/b67c829d-212a-4e75-8813-3136fe29ff12.yml
@@ -46,6 +46,12 @@ default:
   content_translation_outdated:
     -
       value: false
+  content_translation_uid:
+    -
+      target_id: 1
   content_translation_status:
     -
       value: true
+  content_translation_created:
+    -
+      value: 1681809202

--- a/packages/drupal/test_content/content/menu_link_content/e11597b6-1cf4-4efa-ba07-89ab157b8897.yml
+++ b/packages/drupal/test_content/content/menu_link_content/e11597b6-1cf4-4efa-ba07-89ab157b8897.yml
@@ -46,6 +46,12 @@ default:
   content_translation_outdated:
     -
       value: false
+  content_translation_uid:
+    -
+      target_id: 1
   content_translation_status:
     -
       value: true
+  content_translation_created:
+    -
+      value: 1681809202

--- a/packages/drupal/test_content/content/menu_link_content/fa448fd3-23ac-4a84-84d9-dd77e543a720.yml
+++ b/packages/drupal/test_content/content/menu_link_content/fa448fd3-23ac-4a84-84d9-dd77e543a720.yml
@@ -42,9 +42,15 @@ default:
   content_translation_outdated:
     -
       value: false
+  content_translation_uid:
+    -
+      target_id: 1
   content_translation_status:
     -
       value: true
+  content_translation_created:
+    -
+      value: 1681809202
 translations:
   de:
     title:

--- a/packages/drupal/test_content/content/menu_link_content/fc595197-9c7c-4f9d-871f-6d5e32085590.yml
+++ b/packages/drupal/test_content/content/menu_link_content/fc595197-9c7c-4f9d-871f-6d5e32085590.yml
@@ -42,6 +42,12 @@ default:
   content_translation_outdated:
     -
       value: false
+  content_translation_uid:
+    -
+      target_id: 1
   content_translation_status:
     -
       value: true
+  content_translation_created:
+    -
+      value: 1681809202

--- a/packages/drupal/test_content/content/node/27e96820-06f0-400e-8b4b-6b598349d906.yml
+++ b/packages/drupal/test_content/content/node/27e96820-06f0-400e-8b4b-6b598349d906.yml
@@ -36,12 +36,7 @@ default:
     -
       alias: /frameworks
       langcode: en
-      pathauto: 1
-  external_preview_link:
-    -
-      uri: 'http://localhost:8000/__preview/page?nid=5&rid=28&lang=en'
-      title: 'Preview Frameworks'
-      options: {  }
+      pathauto: 0
   content_translation_source:
     -
       value: und

--- a/packages/drupal/test_content/content/node/3a026abf-39d5-4c81-a76e-6f30593f114d.yml
+++ b/packages/drupal/test_content/content/node/3a026abf-39d5-4c81-a76e-6f30593f114d.yml
@@ -36,12 +36,7 @@ default:
     -
       alias: /technologies
       langcode: en
-      pathauto: 1
-  external_preview_link:
-    -
-      uri: 'http://localhost:8000/__preview/page?nid=2&rid=31&lang=en'
-      title: 'Preview Technologies'
-      options: {  }
+      pathauto: 0
   content_translation_source:
     -
       value: und

--- a/packages/drupal/test_content/content/node/491876a1-e2b8-4472-98e5-1c9e1e0d0376.yml
+++ b/packages/drupal/test_content/content/node/491876a1-e2b8-4472-98e5-1c9e1e0d0376.yml
@@ -36,12 +36,7 @@ default:
     -
       alias: /gatsby
       langcode: en
-      pathauto: 1
-  external_preview_link:
-    -
-      uri: 'http://localhost:8000/__preview/page?nid=7&rid=27&lang=en'
-      title: 'Preview Gatsby'
-      options: {  }
+      pathauto: 0
   content_translation_source:
     -
       value: und

--- a/packages/drupal/test_content/content/node/50a28359-32f7-48ee-9577-330d79a2b62c.yml
+++ b/packages/drupal/test_content/content/node/50a28359-32f7-48ee-9577-330d79a2b62c.yml
@@ -26,6 +26,9 @@ default:
   sticky:
     -
       value: false
+  revision_translation_affected:
+    -
+      value: true
   moderation_state:
     -
       value: published
@@ -33,12 +36,7 @@ default:
     -
       alias: /privacy
       langcode: en
-      pathauto: 1
-  external_preview_link:
-    -
-      uri: 'http://localhost:8000/__preview/page?nid=10&rid=25&lang=en'
-      title: 'Preview Privacy'
-      options: {  }
+      pathauto: 0
   content_translation_source:
     -
       value: und
@@ -80,12 +78,7 @@ translations:
       -
         alias: /privatsphaere
         langcode: de
-        pathauto: 1
-    external_preview_link:
-      -
-        uri: 'http://localhost:8000/__preview/page?nid=10&rid=25&lang=de'
-        title: 'Preview Privatsphäre'
-        options: {  }
+        pathauto: 0
     content_translation_source:
       -
         value: en

--- a/packages/drupal/test_content/content/node/60a95f4f-75a6-4de2-ae3e-ba81522d6237.yml
+++ b/packages/drupal/test_content/content/node/60a95f4f-75a6-4de2-ae3e-ba81522d6237.yml
@@ -26,6 +26,9 @@ default:
   sticky:
     -
       value: false
+  revision_translation_affected:
+    -
+      value: true
   moderation_state:
     -
       value: published
@@ -33,12 +36,7 @@ default:
     -
       alias: /404-not-found
       langcode: en
-      pathauto: 1
-  external_preview_link:
-    -
-      uri: 'http://localhost:8000/__preview/page?nid=2&rid=14&lang=en'
-      title: 'Preview 404 - Not found'
-      options: {  }
+      pathauto: 0
   content_translation_source:
     -
       value: und
@@ -80,12 +78,7 @@ translations:
       -
         alias: /404-nicht-gefunden
         langcode: de
-        pathauto: 1
-    external_preview_link:
-      -
-        uri: 'http://localhost:8000/__preview/page?nid=2&rid=14&lang=de'
-        title: 'Preview 404 - Nicht gefunden'
-        options: {  }
+        pathauto: 0
     content_translation_source:
       -
         value: en

--- a/packages/drupal/test_content/content/node/6a25700d-15c8-4671-ab9b-b9d1fd1adc65.yml
+++ b/packages/drupal/test_content/content/node/6a25700d-15c8-4671-ab9b-b9d1fd1adc65.yml
@@ -36,12 +36,7 @@ default:
     -
       alias: /react
       langcode: en
-      pathauto: 1
-  external_preview_link:
-    -
-      uri: 'http://localhost:8000/__preview/page?nid=4&rid=30&lang=en'
-      title: 'Preview React'
-      options: {  }
+      pathauto: 0
   content_translation_source:
     -
       value: und

--- a/packages/drupal/test_content/content/node/7ab4936d-b264-46f7-815f-5c7e1270b6bf.yml
+++ b/packages/drupal/test_content/content/node/7ab4936d-b264-46f7-815f-5c7e1270b6bf.yml
@@ -34,14 +34,9 @@ default:
       value: published
   path:
     -
-      alias: /graphql
+      alias: /graphql-page
       langcode: en
-      pathauto: 1
-  external_preview_link:
-    -
-      uri: 'http://localhost:8000/__preview/page?nid=3&rid=36&lang=en'
-      title: 'Preview GraphQL'
-      options: {  }
+      pathauto: 0
   content_translation_source:
     -
       value: und

--- a/packages/drupal/test_content/content/node/c14dccc3-bc3f-40dc-88b7-d349249311a8.yml
+++ b/packages/drupal/test_content/content/node/c14dccc3-bc3f-40dc-88b7-d349249311a8.yml
@@ -24,6 +24,9 @@ translations:
     sticky:
       -
         value: false
+    revision_translation_affected:
+      -
+        value: true
     moderation_state:
       -
         value: published
@@ -31,12 +34,7 @@ translations:
       -
         alias: /imprint
         langcode: en
-        pathauto: 1
-    external_preview_link:
-      -
-        uri: 'http://localhost:8000/__preview/page?nid=9&rid=24&lang=en'
-        title: 'Preview Imprint'
-        options: {  }
+        pathauto: 0
     content_translation_source:
       -
         value: de
@@ -80,12 +78,7 @@ default:
     -
       alias: /impressum
       langcode: de
-      pathauto: 1
-  external_preview_link:
-    -
-      uri: 'http://localhost:8000/__preview/page?nid=9&rid=24&lang=de'
-      title: 'Preview Impressum'
-      options: {  }
+      pathauto: 0
   content_translation_source:
     -
       value: und

--- a/packages/drupal/test_content/content/node/cc26992f-0ddd-4e54-83a8-4d2f9ad93252.yml
+++ b/packages/drupal/test_content/content/node/cc26992f-0ddd-4e54-83a8-4d2f9ad93252.yml
@@ -36,12 +36,7 @@ default:
     -
       alias: /php
       langcode: en
-      pathauto: 1
-  external_preview_link:
-    -
-      uri: 'http://localhost:8000/__preview/page?nid=8&rid=26&lang=en'
-      title: 'Preview PHP'
-      options: {  }
+      pathauto: 0
   content_translation_source:
     -
       value: und

--- a/packages/drupal/test_content/content/node/f1f827c9-ed06-4e7d-b89d-a169e70a459c.yml
+++ b/packages/drupal/test_content/content/node/f1f827c9-ed06-4e7d-b89d-a169e70a459c.yml
@@ -36,12 +36,7 @@ default:
     -
       alias: /drupal
       langcode: en
-      pathauto: 1
-  external_preview_link:
-    -
-      uri: 'http://localhost:8000/__preview/page?nid=6&rid=32&lang=en'
-      title: 'Preview Drupal'
-      options: {  }
+      pathauto: 0
   content_translation_source:
     -
       value: und

--- a/packages/drupal/test_content/content/node/f815e611-b92d-4ad7-878f-22d0dce1cec8.yml
+++ b/packages/drupal/test_content/content/node/f815e611-b92d-4ad7-878f-22d0dce1cec8.yml
@@ -36,12 +36,7 @@ default:
     -
       alias: /architecture
       langcode: en
-      pathauto: 1
-  external_preview_link:
-    -
-      uri: 'http://localhost:8000/__preview/page?nid=1&rid=17&lang=en'
-      title: 'Preview Architecture'
-      options: {  }
+      pathauto: 0
   content_translation_source:
     -
       value: und
@@ -73,6 +68,9 @@ translations:
     sticky:
       -
         value: false
+    revision_translation_affected:
+      -
+        value: true
     moderation_state:
       -
         value: published
@@ -80,12 +78,7 @@ translations:
       -
         alias: /architektur
         langcode: de
-        pathauto: 1
-    external_preview_link:
-      -
-        uri: 'http://localhost:8000/__preview/page?nid=1&rid=17&lang=de'
-        title: 'Preview Architektur'
-        options: {  }
+        pathauto: 0
     content_translation_source:
       -
         value: en


### PR DESCRIPTION
## Description of changes

- patch for `drupal/default_content` which allows to alter exported data
- removed `external_preview_link` from export
- fix for path aliases

## How has this been tested?

- [x] Manually
- [ ] Unit tests
- [ ] Integration tests