### PR TITLE
chore: lock react version

### DIFF
--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -13,8 +13,8 @@
     "gatsby-plugin-netlify": "^5.1.0",
     "gatsby-plugin-pnpm": "^1.2.10",
     "netlify-cli": "^14.3.0",
-    "react": "experimental",
-    "react-dom": "experimental"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -48,8 +48,8 @@
     "framer-motion": "^10.12.4"
   },
   "peerDependencies": {
-    "react": "experimental",
-    "react-dom": "experimental"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "@amazeelabs/cloudinary-responsive-image": "^1.2.5",
@@ -86,8 +86,8 @@
     "postcss-cli": "^10.1.0",
     "postcss-import": "^15.1.0",
     "postcss-import-ext-glob": "^2.1.1",
-    "react": "experimental",
-    "react-dom": "experimental",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "serve": "^14.2.0",
     "start-server-and-test": "^2.0.0",
     "storybook": "^7.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,7 +92,7 @@ importers:
         version: 1.10.5(gatsby@5.9.0)
       '@amazeelabs/publisher':
         specifier: ^2.1.17
-        version: 2.1.17(react@0.0.0-experimental-5309f1028-20230517)(typescript@4.9.5)
+        version: 2.1.17(react@18.2.0)(typescript@4.9.5)
       '@custom/schema':
         specifier: workspace:*
         version: link:../../packages/schema
@@ -101,7 +101,7 @@ importers:
         version: link:../../packages/ui
       gatsby:
         specifier: ^5.9.0
-        version: 5.9.0(patch_hash=ccio6t4d6ydqz55f7tt4vaiyd4)(babel-eslint@10.1.0)(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)(typescript@4.9.5)
+        version: 5.9.0(patch_hash=ccio6t4d6ydqz55f7tt4vaiyd4)(babel-eslint@10.1.0)(react-dom@18.2.0)(react@18.2.0)(typescript@4.9.5)
       gatsby-plugin-manifest:
         specifier: ^5.9.0
         version: 5.9.0(gatsby@5.9.0)(graphql@16.6.0)
@@ -115,15 +115,15 @@ importers:
         specifier: ^14.3.0
         version: 14.3.0(@types/node@18.16.1)
       react:
-        specifier: experimental
-        version: 0.0.0-experimental-5309f1028-20230517
+        specifier: ^18.2.0
+        version: 18.2.0
       react-dom:
-        specifier: experimental
-        version: 0.0.0-experimental-5309f1028-20230517(react@0.0.0-experimental-5309f1028-20230517)
+        specifier: ^18.2.0
+        version: 18.2.0(react@18.2.0)
     devDependencies:
       '@testing-library/react':
         specifier: ^14.0.0
-        version: 14.0.0(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)
+        version: 14.0.0(react-dom@18.2.0)(react@18.2.0)
       '@types/react':
         specifier: ^18.2.0
         version: 18.2.0
@@ -236,22 +236,22 @@ importers:
     dependencies:
       '@amazeelabs/react-intl-rsc':
         specifier: ^1.1.9
-        version: 1.1.9(react@0.0.0-experimental-5309f1028-20230517)
+        version: 1.1.9(react@18.2.0)
       '@custom/schema':
         specifier: workspace:*
         version: link:../schema
       '@headlessui/react':
         specifier: ^1.7.14
-        version: 1.7.14(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)
+        version: 1.7.14(react-dom@18.2.0)(react@18.2.0)
       '@heroicons/react':
         specifier: ^2.0.17
-        version: 2.0.17(react@0.0.0-experimental-5309f1028-20230517)
+        version: 2.0.17(react@18.2.0)
       clsx:
         specifier: ^1.2.1
         version: 1.2.1
       framer-motion:
         specifier: ^10.12.4
-        version: 10.12.4(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)
+        version: 10.12.4(react-dom@18.2.0)(react@18.2.0)
       hast-util-is-element:
         specifier: ^2.1.3
         version: 2.1.3
@@ -270,28 +270,28 @@ importers:
         version: 6.1.0
       '@storybook/addon-actions':
         specifier: ^7.0.7
-        version: 7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)
+        version: 7.0.7(react-dom@18.2.0)(react@18.2.0)
       '@storybook/addon-coverage':
         specifier: ^0.0.8
         version: 0.0.8
       '@storybook/addon-essentials':
         specifier: ^7.0.7
-        version: 7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)
+        version: 7.0.7(react-dom@18.2.0)(react@18.2.0)
       '@storybook/addon-interactions':
         specifier: ^7.0.7
-        version: 7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)
+        version: 7.0.7(react-dom@18.2.0)(react@18.2.0)
       '@storybook/addon-links':
         specifier: ^7.0.7
-        version: 7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)
+        version: 7.0.7(react-dom@18.2.0)(react@18.2.0)
       '@storybook/blocks':
         specifier: ^7.0.7
-        version: 7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)
+        version: 7.0.7(react-dom@18.2.0)(react@18.2.0)
       '@storybook/react':
         specifier: ^7.0.7
-        version: 7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)(typescript@5.0.4)
+        version: 7.0.7(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.4)
       '@storybook/react-vite':
         specifier: ^7.0.7
-        version: 7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)(typescript@5.0.4)(vite@4.3.2)
+        version: 7.0.7(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.4)(vite@4.3.2)
       '@storybook/test-runner':
         specifier: ^0.10.0
         version: 0.10.0(@types/node@18.16.1)(ts-node@10.9.1)
@@ -318,7 +318,7 @@ importers:
         version: 0.5.9(tailwindcss@3.3.2)
       '@testing-library/react':
         specifier: ^14.0.0
-        version: 14.0.0(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)
+        version: 14.0.0(react-dom@18.2.0)(react@18.2.0)
       '@types/hast':
         specifier: ^2.3.4
         version: 2.3.4
@@ -371,11 +371,11 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1(postcss@8.4.23)
       react:
-        specifier: experimental
-        version: 0.0.0-experimental-5309f1028-20230517
+        specifier: ^18.2.0
+        version: 18.2.0
       react-dom:
-        specifier: experimental
-        version: 0.0.0-experimental-5309f1028-20230517(react@0.0.0-experimental-5309f1028-20230517)
+        specifier: ^18.2.0
+        version: 18.2.0(react@18.2.0)
       serve:
         specifier: ^14.2.0
         version: 14.2.0
@@ -572,7 +572,7 @@ packages:
     resolution: {integrity: sha512-sK2tqx/1OzJM6LK/KZSllF2pFpKSolR2jDCFhHULxFCcLmSUJzPbe/Ojyl77EwQAaMgvDvhc+mlT1ANwXP7mOA==}
     dev: false
 
-  /@amazeelabs/publisher@2.1.17(react@0.0.0-experimental-5309f1028-20230517)(typescript@4.9.5):
+  /@amazeelabs/publisher@2.1.17(react@18.2.0)(typescript@4.9.5):
     resolution: {integrity: sha512-bgXI7+9PDNB4WCKxtQKssKyaVdBAdvEpaPaKu0EHuI+9ElbOpskCkD/QofzVrL52WZlUxHvFFNp/otKjseBCfw==}
     engines: {node: '>=16'}
     hasBin: true
@@ -595,7 +595,7 @@ packages:
       strip-ansi: 7.0.1
       terminate: 2.6.1
       ts-import: 4.0.0-beta.10(typescript@4.9.5)
-      zustand: 4.3.6(react@0.0.0-experimental-5309f1028-20230517)
+      zustand: 4.3.6(react@18.2.0)
     transitivePeerDependencies:
       - '@types/express'
       - bluebird
@@ -617,13 +617,13 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@amazeelabs/react-intl-rsc@1.1.9(react@0.0.0-experimental-5309f1028-20230517):
+  /@amazeelabs/react-intl-rsc@1.1.9(react@18.2.0):
     resolution: {integrity: sha512-f+exgDz1/yAw2o7X07QpB0hf0rtCa/qJGfubfzpdfOBfnjpj0oXF7eMaSeo4bdlS24Y3SoYUsn+08J5GmgNYYA==}
     peerDependencies:
       react: ^18.2.0
     dependencies:
-      react: 0.0.0-experimental-5309f1028-20230517
-      react-intl: 6.4.1(react@0.0.0-experimental-5309f1028-20230517)(typescript@5.0.4)
+      react: 18.2.0
+      react-intl: 6.4.1(react@18.2.0)(typescript@5.0.4)
     optionalDependencies:
       '@types/react': 18.2.0
       typescript: 5.0.4
@@ -2283,12 +2283,12 @@ packages:
     dev: false
     optional: true
 
-  /@emotion/use-insertion-effect-with-fallbacks@1.0.0(react@0.0.0-experimental-5309f1028-20230517):
+  /@emotion/use-insertion-effect-with-fallbacks@1.0.0(react@18.2.0):
     resolution: {integrity: sha512-1eEgUGmkaljiBnRMTdksDV1W4kUnmwgp7X9G8B++9GYwl1lUdqSndSriIrTJ0N7LQaoauY9JJ2yhiOYK5+NI4A==}
     peerDependencies:
       react: '>=16.8.0'
     dependencies:
-      react: 0.0.0-experimental-5309f1028-20230517
+      react: 18.2.0
     dev: true
 
   /@esbuild/android-arm64@0.17.18:
@@ -2679,7 +2679,7 @@ packages:
       - '@parcel/core'
     dev: false
 
-  /@gatsbyjs/reach-router@2.0.1(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517):
+  /@gatsbyjs/reach-router@2.0.1(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-gmSZniS9/phwgEgpFARMpNg21PkYDZEpfgEzvkgpE/iku4uvXqCrxr86fXbTpI9mkrhKS1SCTYmLGe60VdHcdQ==}
     peerDependencies:
       react: 18.x
@@ -2687,8 +2687,8 @@ packages:
     dependencies:
       invariant: 2.2.4
       prop-types: 15.8.1
-      react: 0.0.0-experimental-5309f1028-20230517
-      react-dom: 0.0.0-experimental-5309f1028-20230517(react@0.0.0-experimental-5309f1028-20230517)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
   /@gatsbyjs/webpack-hot-middleware@2.25.3:
@@ -3322,7 +3322,7 @@ packages:
     dependencies:
       '@hapi/hoek': 9.3.0
 
-  /@headlessui/react@1.7.14(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517):
+  /@headlessui/react@1.7.14(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-znzdq9PG8rkwcu9oQ2FwIy0ZFtP9Z7ycS+BAqJ3R5EIqC/0bJGvhT7193rFf+45i9nnPsYvCQVW4V/bB9Xc+gA==}
     engines: {node: '>=10'}
     peerDependencies:
@@ -3330,16 +3330,16 @@ packages:
       react-dom: ^16 || ^17 || ^18
     dependencies:
       client-only: 0.0.1
-      react: 0.0.0-experimental-5309f1028-20230517
-      react-dom: 0.0.0-experimental-5309f1028-20230517(react@0.0.0-experimental-5309f1028-20230517)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /@heroicons/react@2.0.17(react@0.0.0-experimental-5309f1028-20230517):
+  /@heroicons/react@2.0.17(react@18.2.0):
     resolution: {integrity: sha512-90GMZktkA53YbNzHp6asVEDevUQCMtxWH+2UK2S8OpnLEu7qckTJPhNxNQG52xIR1WFTwFqtH6bt7a60ZNcLLA==}
     peerDependencies:
       react: '>= 16'
     dependencies:
-      react: 0.0.0-experimental-5309f1028-20230517
+      react: 18.2.0
     dev: false
 
   /@humanwhocodes/config-array@0.11.8:
@@ -3903,14 +3903,14 @@ packages:
       - supports-color
     dev: false
 
-  /@mdx-js/react@2.3.0(react@0.0.0-experimental-5309f1028-20230517):
+  /@mdx-js/react@2.3.0(react@18.2.0):
     resolution: {integrity: sha512-zQH//gdOmuu7nt2oJR29vFhDv88oGPmVw6BggmrHeMI+xgEkp1B2dX9/bMBSYtK0dyLX/aOmesKS09g222K1/g==}
     peerDependencies:
       react: '>=16'
     dependencies:
       '@types/mdx': 2.0.4
       '@types/react': 18.2.0
-      react: 0.0.0-experimental-5309f1028-20230517
+      react: 18.2.0
     dev: true
 
   /@mischnic/json-sourcemap@0.1.0:
@@ -5414,7 +5414,7 @@ packages:
     resolution: {integrity: sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==}
     dev: false
 
-  /@storybook/addon-actions@7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517):
+  /@storybook/addon-actions@7.0.7(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-WxsnSjAvdf6NhUfTqcwV+FJmsJV56gh2cY4QnGfqfwO5zoBWTUYnhz57TgxSMhJY0kspyX9Q1Kc//r1d5lt1qA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -5426,26 +5426,26 @@ packages:
         optional: true
     dependencies:
       '@storybook/client-logger': 7.0.7
-      '@storybook/components': 7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)
+      '@storybook/components': 7.0.7(react-dom@18.2.0)(react@18.2.0)
       '@storybook/core-events': 7.0.7
       '@storybook/global': 5.0.0
-      '@storybook/manager-api': 7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)
+      '@storybook/manager-api': 7.0.7(react-dom@18.2.0)(react@18.2.0)
       '@storybook/preview-api': 7.0.7
-      '@storybook/theming': 7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)
+      '@storybook/theming': 7.0.7(react-dom@18.2.0)(react@18.2.0)
       '@storybook/types': 7.0.7
       dequal: 2.0.3
       lodash: 4.17.21
       polished: 4.2.2
       prop-types: 15.8.1
-      react: 0.0.0-experimental-5309f1028-20230517
-      react-dom: 0.0.0-experimental-5309f1028-20230517(react@0.0.0-experimental-5309f1028-20230517)
-      react-inspector: 6.0.1(react@0.0.0-experimental-5309f1028-20230517)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      react-inspector: 6.0.1(react@18.2.0)
       telejson: 7.1.0
       ts-dedent: 2.2.0
       uuid: 9.0.0
     dev: true
 
-  /@storybook/addon-backgrounds@7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517):
+  /@storybook/addon-backgrounds@7.0.7(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-DhT32K1+ti7MXY9oqt36b9jlg7iY68IP0ZQbR3gjShcsIXZpFqh18TQo0vwDY1ldqnBvkTk6Jd5vcxA8tfyshw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -5457,20 +5457,20 @@ packages:
         optional: true
     dependencies:
       '@storybook/client-logger': 7.0.7
-      '@storybook/components': 7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)
+      '@storybook/components': 7.0.7(react-dom@18.2.0)(react@18.2.0)
       '@storybook/core-events': 7.0.7
       '@storybook/global': 5.0.0
-      '@storybook/manager-api': 7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)
+      '@storybook/manager-api': 7.0.7(react-dom@18.2.0)(react@18.2.0)
       '@storybook/preview-api': 7.0.7
-      '@storybook/theming': 7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)
+      '@storybook/theming': 7.0.7(react-dom@18.2.0)(react@18.2.0)
       '@storybook/types': 7.0.7
       memoizerific: 1.11.3
-      react: 0.0.0-experimental-5309f1028-20230517
-      react-dom: 0.0.0-experimental-5309f1028-20230517(react@0.0.0-experimental-5309f1028-20230517)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
       ts-dedent: 2.2.0
     dev: true
 
-  /@storybook/addon-controls@7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517):
+  /@storybook/addon-controls@7.0.7(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-/QEzleKoWRQ3i7KB32QvqDGcGMw4kG2BxEf0d+ymxd2SjoeL6kX2eHE0b4OxFPXiWUyTfXBFwmcI2Re3fRUJnQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -5481,18 +5481,18 @@ packages:
       react-dom:
         optional: true
     dependencies:
-      '@storybook/blocks': 7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)
+      '@storybook/blocks': 7.0.7(react-dom@18.2.0)(react@18.2.0)
       '@storybook/client-logger': 7.0.7
-      '@storybook/components': 7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)
+      '@storybook/components': 7.0.7(react-dom@18.2.0)(react@18.2.0)
       '@storybook/core-common': 7.0.7
-      '@storybook/manager-api': 7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)
+      '@storybook/manager-api': 7.0.7(react-dom@18.2.0)(react@18.2.0)
       '@storybook/node-logger': 7.0.7
       '@storybook/preview-api': 7.0.7
-      '@storybook/theming': 7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)
+      '@storybook/theming': 7.0.7(react-dom@18.2.0)(react@18.2.0)
       '@storybook/types': 7.0.7
       lodash: 4.17.21
-      react: 0.0.0-experimental-5309f1028-20230517
-      react-dom: 0.0.0-experimental-5309f1028-20230517(react@0.0.0-experimental-5309f1028-20230517)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - supports-color
@@ -5510,7 +5510,7 @@ packages:
       - supports-color
     dev: true
 
-  /@storybook/addon-docs@7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517):
+  /@storybook/addon-docs@7.0.7(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-5PT7aiTD6QPH+4CZLcv4PiUgWucD9JNGHVMRbQMEyFW6qbs87dHmu1m1uXIvx3BF5h3mTo4FHNAf8IQIq5HH9w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -5519,10 +5519,10 @@ packages:
       '@babel/core': 7.21.4
       '@babel/plugin-transform-react-jsx': 7.21.0(@babel/core@7.21.4)
       '@jest/transform': 29.5.0
-      '@mdx-js/react': 2.3.0(react@0.0.0-experimental-5309f1028-20230517)
-      '@storybook/blocks': 7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)
+      '@mdx-js/react': 2.3.0(react@18.2.0)
+      '@storybook/blocks': 7.0.7(react-dom@18.2.0)(react@18.2.0)
       '@storybook/client-logger': 7.0.7
-      '@storybook/components': 7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)
+      '@storybook/components': 7.0.7(react-dom@18.2.0)(react@18.2.0)
       '@storybook/csf-plugin': 7.0.7
       '@storybook/csf-tools': 7.0.7
       '@storybook/global': 5.0.0
@@ -5530,12 +5530,12 @@ packages:
       '@storybook/node-logger': 7.0.7
       '@storybook/postinstall': 7.0.7
       '@storybook/preview-api': 7.0.7
-      '@storybook/react-dom-shim': 7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)
-      '@storybook/theming': 7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)
+      '@storybook/react-dom-shim': 7.0.7(react-dom@18.2.0)(react@18.2.0)
+      '@storybook/theming': 7.0.7(react-dom@18.2.0)(react@18.2.0)
       '@storybook/types': 7.0.7
       fs-extra: 11.1.1
-      react: 0.0.0-experimental-5309f1028-20230517
-      react-dom: 0.0.0-experimental-5309f1028-20230517(react@0.0.0-experimental-5309f1028-20230517)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
       remark-external-links: 8.0.0
       remark-slug: 6.1.0
       ts-dedent: 2.2.0
@@ -5543,28 +5543,28 @@ packages:
       - supports-color
     dev: true
 
-  /@storybook/addon-essentials@7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517):
+  /@storybook/addon-essentials@7.0.7(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-uNx0BvN1XP7cNnk/L4oiFQlEB/KABqOeIyI8/mhfIyTvvwo9uAYIQAyiwWuz9MFmofCNm7CgLNOUaEwNDkM4CA==}
     requiresBuild: true
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
     dependencies:
-      '@storybook/addon-actions': 7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)
-      '@storybook/addon-backgrounds': 7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)
-      '@storybook/addon-controls': 7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)
-      '@storybook/addon-docs': 7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)
+      '@storybook/addon-actions': 7.0.7(react-dom@18.2.0)(react@18.2.0)
+      '@storybook/addon-backgrounds': 7.0.7(react-dom@18.2.0)(react@18.2.0)
+      '@storybook/addon-controls': 7.0.7(react-dom@18.2.0)(react@18.2.0)
+      '@storybook/addon-docs': 7.0.7(react-dom@18.2.0)(react@18.2.0)
       '@storybook/addon-highlight': 7.0.7
-      '@storybook/addon-measure': 7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)
-      '@storybook/addon-outline': 7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)
-      '@storybook/addon-toolbars': 7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)
-      '@storybook/addon-viewport': 7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)
+      '@storybook/addon-measure': 7.0.7(react-dom@18.2.0)(react@18.2.0)
+      '@storybook/addon-outline': 7.0.7(react-dom@18.2.0)(react@18.2.0)
+      '@storybook/addon-toolbars': 7.0.7(react-dom@18.2.0)(react@18.2.0)
+      '@storybook/addon-viewport': 7.0.7(react-dom@18.2.0)(react@18.2.0)
       '@storybook/core-common': 7.0.7
-      '@storybook/manager-api': 7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)
+      '@storybook/manager-api': 7.0.7(react-dom@18.2.0)(react@18.2.0)
       '@storybook/node-logger': 7.0.7
       '@storybook/preview-api': 7.0.7
-      react: 0.0.0-experimental-5309f1028-20230517
-      react-dom: 0.0.0-experimental-5309f1028-20230517(react@0.0.0-experimental-5309f1028-20230517)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - supports-color
@@ -5578,7 +5578,7 @@ packages:
       '@storybook/preview-api': 7.0.7
     dev: true
 
-  /@storybook/addon-interactions@7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517):
+  /@storybook/addon-interactions@7.0.7(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-jBl6O5sSbix0X1G9dFuWvvu4qefgLP9dAB/utVdDadZxlbPfa5B2C2q2YIqjcKZoX8DS8Fh8SUhlX1mdW5tu5w==}
     requiresBuild: true
     peerDependencies:
@@ -5591,25 +5591,25 @@ packages:
         optional: true
     dependencies:
       '@storybook/client-logger': 7.0.7
-      '@storybook/components': 7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)
+      '@storybook/components': 7.0.7(react-dom@18.2.0)(react@18.2.0)
       '@storybook/core-common': 7.0.7
       '@storybook/core-events': 7.0.7
       '@storybook/global': 5.0.0
       '@storybook/instrumenter': 7.0.7
-      '@storybook/manager-api': 7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)
+      '@storybook/manager-api': 7.0.7(react-dom@18.2.0)(react@18.2.0)
       '@storybook/preview-api': 7.0.7
-      '@storybook/theming': 7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)
+      '@storybook/theming': 7.0.7(react-dom@18.2.0)(react@18.2.0)
       '@storybook/types': 7.0.7
       jest-mock: 27.5.1
       polished: 4.2.2
-      react: 0.0.0-experimental-5309f1028-20230517
-      react-dom: 0.0.0-experimental-5309f1028-20230517(react@0.0.0-experimental-5309f1028-20230517)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@storybook/addon-links@7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517):
+  /@storybook/addon-links@7.0.7(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-DEjDxjHb3mT8Sdnx4In5Ev9gJ/XdjlHOq4iuy0wnMyrCV4wnzTQnIeSCx8nkrXFb314zc33JPnCcrb5pQoD5GQ==}
     requiresBuild: true
     peerDependencies:
@@ -5625,17 +5625,17 @@ packages:
       '@storybook/core-events': 7.0.7
       '@storybook/csf': 0.1.0
       '@storybook/global': 5.0.0
-      '@storybook/manager-api': 7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)
+      '@storybook/manager-api': 7.0.7(react-dom@18.2.0)(react@18.2.0)
       '@storybook/preview-api': 7.0.7
-      '@storybook/router': 7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)
+      '@storybook/router': 7.0.7(react-dom@18.2.0)(react@18.2.0)
       '@storybook/types': 7.0.7
       prop-types: 15.8.1
-      react: 0.0.0-experimental-5309f1028-20230517
-      react-dom: 0.0.0-experimental-5309f1028-20230517(react@0.0.0-experimental-5309f1028-20230517)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
       ts-dedent: 2.2.0
     dev: true
 
-  /@storybook/addon-measure@7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517):
+  /@storybook/addon-measure@7.0.7(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-lb4wEIvIVF+ePx1sC+n9rDI0+49sRa6MWbcvZ+BhbAoCeGcX7uACQFdW6HyXolmBuZASsTnzVQ4KqzzvY1dSWw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -5647,17 +5647,17 @@ packages:
         optional: true
     dependencies:
       '@storybook/client-logger': 7.0.7
-      '@storybook/components': 7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)
+      '@storybook/components': 7.0.7(react-dom@18.2.0)(react@18.2.0)
       '@storybook/core-events': 7.0.7
       '@storybook/global': 5.0.0
-      '@storybook/manager-api': 7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)
+      '@storybook/manager-api': 7.0.7(react-dom@18.2.0)(react@18.2.0)
       '@storybook/preview-api': 7.0.7
       '@storybook/types': 7.0.7
-      react: 0.0.0-experimental-5309f1028-20230517
-      react-dom: 0.0.0-experimental-5309f1028-20230517(react@0.0.0-experimental-5309f1028-20230517)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: true
 
-  /@storybook/addon-outline@7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517):
+  /@storybook/addon-outline@7.0.7(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-AxbNZ4N1fXBTeMYM9tFudfW+Gzq7UikCjPxn5ax3Pde+zZjaEMppUxv5EMz4g5GIJupLYRmKH5pN0YcYoRLY6w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -5669,18 +5669,18 @@ packages:
         optional: true
     dependencies:
       '@storybook/client-logger': 7.0.7
-      '@storybook/components': 7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)
+      '@storybook/components': 7.0.7(react-dom@18.2.0)(react@18.2.0)
       '@storybook/core-events': 7.0.7
       '@storybook/global': 5.0.0
-      '@storybook/manager-api': 7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)
+      '@storybook/manager-api': 7.0.7(react-dom@18.2.0)(react@18.2.0)
       '@storybook/preview-api': 7.0.7
       '@storybook/types': 7.0.7
-      react: 0.0.0-experimental-5309f1028-20230517
-      react-dom: 0.0.0-experimental-5309f1028-20230517(react@0.0.0-experimental-5309f1028-20230517)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
       ts-dedent: 2.2.0
     dev: true
 
-  /@storybook/addon-toolbars@7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517):
+  /@storybook/addon-toolbars@7.0.7(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-/NkYHhU1VAz5lXjWuV8+ADWB84HzktvZv4jfiKX7Zzu6JVzrBu7FotQSWh3pDqqVwCB50RClUGtcHmSSac9CAQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -5692,15 +5692,15 @@ packages:
         optional: true
     dependencies:
       '@storybook/client-logger': 7.0.7
-      '@storybook/components': 7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)
-      '@storybook/manager-api': 7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)
+      '@storybook/components': 7.0.7(react-dom@18.2.0)(react@18.2.0)
+      '@storybook/manager-api': 7.0.7(react-dom@18.2.0)(react@18.2.0)
       '@storybook/preview-api': 7.0.7
-      '@storybook/theming': 7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)
-      react: 0.0.0-experimental-5309f1028-20230517
-      react-dom: 0.0.0-experimental-5309f1028-20230517(react@0.0.0-experimental-5309f1028-20230517)
+      '@storybook/theming': 7.0.7(react-dom@18.2.0)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: true
 
-  /@storybook/addon-viewport@7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517):
+  /@storybook/addon-viewport@7.0.7(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-znqhd8JFEFoXcAdwYhz1CwrCpVAzhuSyUVBUNDsDs+mgBEfGth4D4abIdWWGcfP6+CmI5ebFHtk443cExZebag==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -5712,19 +5712,19 @@ packages:
         optional: true
     dependencies:
       '@storybook/client-logger': 7.0.7
-      '@storybook/components': 7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)
+      '@storybook/components': 7.0.7(react-dom@18.2.0)(react@18.2.0)
       '@storybook/core-events': 7.0.7
       '@storybook/global': 5.0.0
-      '@storybook/manager-api': 7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)
+      '@storybook/manager-api': 7.0.7(react-dom@18.2.0)(react@18.2.0)
       '@storybook/preview-api': 7.0.7
-      '@storybook/theming': 7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)
+      '@storybook/theming': 7.0.7(react-dom@18.2.0)(react@18.2.0)
       memoizerific: 1.11.3
       prop-types: 15.8.1
-      react: 0.0.0-experimental-5309f1028-20230517
-      react-dom: 0.0.0-experimental-5309f1028-20230517(react@0.0.0-experimental-5309f1028-20230517)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: true
 
-  /@storybook/blocks@7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517):
+  /@storybook/blocks@7.0.7(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-ehR0hAFWNHHqmrmbwYPKhLpgbIBKtyMbeoGClTRSnrVBGONciYJdmxegkCTReUklCY+HBJjtlwNowT+7+5sSaw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -5732,25 +5732,25 @@ packages:
     dependencies:
       '@storybook/channels': 7.0.7
       '@storybook/client-logger': 7.0.7
-      '@storybook/components': 7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)
+      '@storybook/components': 7.0.7(react-dom@18.2.0)(react@18.2.0)
       '@storybook/core-events': 7.0.7
       '@storybook/csf': 0.1.0
       '@storybook/docs-tools': 7.0.7
       '@storybook/global': 5.0.0
-      '@storybook/manager-api': 7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)
+      '@storybook/manager-api': 7.0.7(react-dom@18.2.0)(react@18.2.0)
       '@storybook/preview-api': 7.0.7
-      '@storybook/theming': 7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)
+      '@storybook/theming': 7.0.7(react-dom@18.2.0)(react@18.2.0)
       '@storybook/types': 7.0.7
       '@types/lodash': 4.14.194
       color-convert: 2.0.1
       dequal: 2.0.3
       lodash: 4.17.21
-      markdown-to-jsx: 7.2.0(react@0.0.0-experimental-5309f1028-20230517)
+      markdown-to-jsx: 7.2.0(react@18.2.0)
       memoizerific: 1.11.3
       polished: 4.2.2
-      react: 0.0.0-experimental-5309f1028-20230517
-      react-colorful: 5.6.1(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)
-      react-dom: 0.0.0-experimental-5309f1028-20230517(react@0.0.0-experimental-5309f1028-20230517)
+      react: 18.2.0
+      react-colorful: 5.6.1(react-dom@18.2.0)(react@18.2.0)
+      react-dom: 18.2.0(react@18.2.0)
       telejson: 7.1.0
       ts-dedent: 2.2.0
       util-deprecate: 1.0.2
@@ -5921,7 +5921,7 @@ packages:
       - supports-color
     dev: true
 
-  /@storybook/components@7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517):
+  /@storybook/components@7.0.7(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-6PLs9LMkBuhH/w4bSJ72tYgICMbOOIHuoB/fQdVlzhsdnXL2fM/v4RVW2N7v+Oz3lYXp/JtV8V9Ub8h6eDQKXg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -5930,12 +5930,12 @@ packages:
       '@storybook/client-logger': 7.0.7
       '@storybook/csf': 0.1.0
       '@storybook/global': 5.0.0
-      '@storybook/theming': 7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)
+      '@storybook/theming': 7.0.7(react-dom@18.2.0)(react@18.2.0)
       '@storybook/types': 7.0.7
       memoizerific: 1.11.3
-      react: 0.0.0-experimental-5309f1028-20230517
-      react-dom: 0.0.0-experimental-5309f1028-20230517(react@0.0.0-experimental-5309f1028-20230517)
-      use-resize-observer: 9.1.0(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      use-resize-observer: 9.1.0(react-dom@18.2.0)(react@18.2.0)
       util-deprecate: 1.0.2
     dev: true
 
@@ -6097,7 +6097,7 @@ packages:
       '@storybook/preview-api': 7.0.7
     dev: true
 
-  /@storybook/manager-api@7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517):
+  /@storybook/manager-api@7.0.7(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-QTd/P72peAhofKqK+8yzIO9iWAEfPn8WUGGveV2KGaTlSlgbr87RLHEKilcXMZcYhBWC9izFRmjKum9ROdskrQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -6108,14 +6108,14 @@ packages:
       '@storybook/core-events': 7.0.7
       '@storybook/csf': 0.1.0
       '@storybook/global': 5.0.0
-      '@storybook/router': 7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)
-      '@storybook/theming': 7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)
+      '@storybook/router': 7.0.7(react-dom@18.2.0)(react@18.2.0)
+      '@storybook/theming': 7.0.7(react-dom@18.2.0)(react@18.2.0)
       '@storybook/types': 7.0.7
       dequal: 2.0.3
       lodash: 4.17.21
       memoizerific: 1.11.3
-      react: 0.0.0-experimental-5309f1028-20230517
-      react-dom: 0.0.0-experimental-5309f1028-20230517(react@0.0.0-experimental-5309f1028-20230517)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
       semver: 7.5.0
       store2: 2.14.2
       telejson: 7.1.0
@@ -6167,17 +6167,17 @@ packages:
     resolution: {integrity: sha512-uL3ZcFao6UvxiSxCIcXKFakxEr9Nn0lvu0zzC2yQCVepzA7a+GDr1cK5VbZ6Mez38CnOvBmb5pkCbgRqSf/oug==}
     dev: true
 
-  /@storybook/react-dom-shim@7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517):
+  /@storybook/react-dom-shim@7.0.7(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-INGwFeu9M+RzpvktSKuwy8Rk/70mXGqxxsb9lPtq7phmETvfpNX7GnLJqiVazTaQiB1DkB0iAPUsK2MNbBu+Kw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
     dependencies:
-      react: 0.0.0-experimental-5309f1028-20230517
-      react-dom: 0.0.0-experimental-5309f1028-20230517(react@0.0.0-experimental-5309f1028-20230517)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: true
 
-  /@storybook/react-vite@7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)(typescript@5.0.4)(vite@4.3.2):
+  /@storybook/react-vite@7.0.7(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.4)(vite@4.3.2):
     resolution: {integrity: sha512-RuWfP/kiLpuHdcF9dWUUp9SOGMmO0FJ0HGV5yAOhGmi8KmTzvc8zjC+hJjj+sSgn2n71BO8pG/zqGl16FwfwVQ==}
     engines: {node: '>=16'}
     requiresBuild: true
@@ -6189,13 +6189,13 @@ packages:
       '@joshwooding/vite-plugin-react-docgen-typescript': 0.2.1(typescript@5.0.4)(vite@4.3.2)
       '@rollup/pluginutils': 4.2.1
       '@storybook/builder-vite': 7.0.7(typescript@5.0.4)(vite@4.3.2)
-      '@storybook/react': 7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)(typescript@5.0.4)
+      '@storybook/react': 7.0.7(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.4)
       '@vitejs/plugin-react': 3.1.0(vite@4.3.2)
       ast-types: 0.14.2
       magic-string: 0.27.0
-      react: 0.0.0-experimental-5309f1028-20230517
+      react: 18.2.0
       react-docgen: 6.0.0-alpha.3
-      react-dom: 0.0.0-experimental-5309f1028-20230517(react@0.0.0-experimental-5309f1028-20230517)
+      react-dom: 18.2.0(react@18.2.0)
       vite: 4.3.2(@types/node@18.16.1)
     transitivePeerDependencies:
       - '@preact/preset-vite'
@@ -6204,7 +6204,7 @@ packages:
       - vite-plugin-glimmerx
     dev: true
 
-  /@storybook/react@7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)(typescript@5.0.4):
+  /@storybook/react@7.0.7(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.4):
     resolution: {integrity: sha512-eEsIfAGumzo7KRi/WKFpn/PGFhwLv72oiEM/8l5MMX/6poIkiekunqJLfx2BoL4cCtiS4g7OYzOdWjN01DwVCg==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
@@ -6220,7 +6220,7 @@ packages:
       '@storybook/docs-tools': 7.0.7
       '@storybook/global': 5.0.0
       '@storybook/preview-api': 7.0.7
-      '@storybook/react-dom-shim': 7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)
+      '@storybook/react-dom-shim': 7.0.7(react-dom@18.2.0)(react@18.2.0)
       '@storybook/types': 7.0.7
       '@types/escodegen': 0.0.6
       '@types/estree': 0.0.51
@@ -6232,9 +6232,9 @@ packages:
       html-tags: 3.3.1
       lodash: 4.17.21
       prop-types: 15.8.1
-      react: 0.0.0-experimental-5309f1028-20230517
-      react-dom: 0.0.0-experimental-5309f1028-20230517(react@0.0.0-experimental-5309f1028-20230517)
-      react-element-to-jsx-string: 15.0.0(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      react-element-to-jsx-string: 15.0.0(react-dom@18.2.0)(react@18.2.0)
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       typescript: 5.0.4
@@ -6243,7 +6243,7 @@ packages:
       - supports-color
     dev: true
 
-  /@storybook/router@7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517):
+  /@storybook/router@7.0.7(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-/lM8/NHQKeshfnC3ayFuO8Y9TCSHnCAPRhIsVxvanBzcj+ILbCIyZ+TspvB3hT4MbX/Ez+JR8VrMbjXIGwmH8w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -6252,8 +6252,8 @@ packages:
       '@storybook/client-logger': 7.0.7
       memoizerific: 1.11.3
       qs: 6.11.1
-      react: 0.0.0-experimental-5309f1028-20230517
-      react-dom: 0.0.0-experimental-5309f1028-20230517(react@0.0.0-experimental-5309f1028-20230517)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: true
 
   /@storybook/telemetry@7.0.7:
@@ -6328,18 +6328,18 @@ packages:
       ts-dedent: 2.2.0
     dev: true
 
-  /@storybook/theming@7.0.7(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517):
+  /@storybook/theming@7.0.7(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-InTZe+Sgco1NsxgiG+cyUKWQe3GsjlIyU/o5qDdtOTXcZ64HzyBuAZlAequSddqfDeMDqxRFPc2w1J28MAUHxA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
     dependencies:
-      '@emotion/use-insertion-effect-with-fallbacks': 1.0.0(react@0.0.0-experimental-5309f1028-20230517)
+      '@emotion/use-insertion-effect-with-fallbacks': 1.0.0(react@18.2.0)
       '@storybook/client-logger': 7.0.7
       '@storybook/global': 5.0.0
       memoizerific: 1.11.3
-      react: 0.0.0-experimental-5309f1028-20230517
-      react-dom: 0.0.0-experimental-5309f1028-20230517(react@0.0.0-experimental-5309f1028-20230517)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: true
 
   /@storybook/types@7.0.7:
@@ -6588,7 +6588,7 @@ packages:
       pretty-format: 27.5.1
     dev: true
 
-  /@testing-library/react@14.0.0(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517):
+  /@testing-library/react@14.0.0(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-S04gSNJbYE30TlIMLTzv6QCTzt9AqIF5y6s6SzVFILNcNvbV/jU96GeiTPillGQo+Ny64M/5PV7klNYYgv5Dfg==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -6598,8 +6598,8 @@ packages:
       '@babel/runtime': 7.21.0
       '@testing-library/dom': 9.3.0
       '@types/react-dom': 18.2.1
-      react: 0.0.0-experimental-5309f1028-20230517
-      react-dom: 0.0.0-experimental-5309f1028-20230517(react@0.0.0-experimental-5309f1028-20230517)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: true
 
   /@testing-library/user-event@13.5.0(@testing-library/dom@8.20.0):
@@ -9228,7 +9228,7 @@ packages:
       '@babel/core': 7.21.4
       '@babel/runtime': 7.21.0
       '@babel/types': 7.21.4
-      gatsby: 5.9.0(patch_hash=ccio6t4d6ydqz55f7tt4vaiyd4)(babel-eslint@10.1.0)(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)(typescript@4.9.5)
+      gatsby: 5.9.0(patch_hash=ccio6t4d6ydqz55f7tt4vaiyd4)(babel-eslint@10.1.0)(react-dom@18.2.0)(react@18.2.0)(typescript@4.9.5)
       gatsby-core-utils: 4.9.0
     dev: false
 
@@ -13771,7 +13771,7 @@ packages:
       map-cache: 0.2.2
     dev: false
 
-  /framer-motion@10.12.4(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517):
+  /framer-motion@10.12.4(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-9gLtv8T6dui0tujHROR+VM3kdJyKiFCFiD94IQE+0OuX6LaIyXtdVpviokVdrHSb1giWhmmX4yzoucALMx6mtw==}
     peerDependencies:
       react: ^18.0.0
@@ -13782,8 +13782,8 @@ packages:
       react-dom:
         optional: true
     dependencies:
-      react: 0.0.0-experimental-5309f1028-20230517
-      react-dom: 0.0.0-experimental-5309f1028-20230517(react@0.0.0-experimental-5309f1028-20230517)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
       tslib: 2.5.0
     optionalDependencies:
       '@emotion/is-prop-valid': 0.8.8
@@ -13982,7 +13982,7 @@ packages:
     dependencies:
       '@types/node-fetch': 2.6.3
       fs-extra: 9.1.0
-      gatsby: 5.9.0(patch_hash=ccio6t4d6ydqz55f7tt4vaiyd4)(babel-eslint@10.1.0)(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)(typescript@4.9.5)
+      gatsby: 5.9.0(patch_hash=ccio6t4d6ydqz55f7tt4vaiyd4)(babel-eslint@10.1.0)(react-dom@18.2.0)(react@18.2.0)(typescript@4.9.5)
       lodash: 4.17.21
       node-fetch: 2.6.9
       p-queue: 6.6.2
@@ -13997,7 +13997,7 @@ packages:
       core-js-compat: 3.9.0
     dev: false
 
-  /gatsby-link@5.9.0(@gatsbyjs/reach-router@2.0.1)(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517):
+  /gatsby-link@5.9.0(@gatsbyjs/reach-router@2.0.1)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-xoa9sJJH4mZBEU41eIoFNPc7x5+z+Ecl2Mqi6LKhQflBg0j5vmCTeDYnRwQ2wC2EwLdb5/Xd9tvMG7r9zlXvag==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
@@ -14005,12 +14005,12 @@ packages:
       react: ^18.0.0 || ^0.0.0
       react-dom: ^18.0.0 || ^0.0.0
     dependencies:
-      '@gatsbyjs/reach-router': 2.0.1(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)
+      '@gatsbyjs/reach-router': 2.0.1(react-dom@18.2.0)(react@18.2.0)
       '@types/reach__router': 1.3.11
       gatsby-page-utils: 3.9.0
       prop-types: 15.8.1
-      react: 0.0.0-experimental-5309f1028-20230517
-      react-dom: 0.0.0-experimental-5309f1028-20230517(react@0.0.0-experimental-5309f1028-20230517)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
   /gatsby-page-utils@3.9.0:
@@ -14055,7 +14055,7 @@ packages:
       gatsby: ^5.0.0-next
     dependencies:
       '@babel/runtime': 7.21.0
-      gatsby: 5.9.0(patch_hash=ccio6t4d6ydqz55f7tt4vaiyd4)(babel-eslint@10.1.0)(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)(typescript@4.9.5)
+      gatsby: 5.9.0(patch_hash=ccio6t4d6ydqz55f7tt4vaiyd4)(babel-eslint@10.1.0)(react-dom@18.2.0)(react@18.2.0)(typescript@4.9.5)
       gatsby-core-utils: 4.9.0
       gatsby-plugin-utils: 4.9.0(gatsby@5.9.0)(graphql@16.6.0)
       semver: 7.5.0
@@ -14072,7 +14072,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.21.0
       fs-extra: 10.1.0
-      gatsby: 5.9.0(patch_hash=ccio6t4d6ydqz55f7tt4vaiyd4)(babel-eslint@10.1.0)(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)(typescript@4.9.5)
+      gatsby: 5.9.0(patch_hash=ccio6t4d6ydqz55f7tt4vaiyd4)(babel-eslint@10.1.0)(react-dom@18.2.0)(react@18.2.0)(typescript@4.9.5)
       gatsby-core-utils: 4.9.0
       kebab-hash: 0.1.2
       lodash.mergewith: 4.6.2
@@ -14093,7 +14093,7 @@ packages:
       chokidar: 3.5.3
       fs-exists-cached: 1.0.0
       fs-extra: 11.1.1
-      gatsby: 5.9.0(patch_hash=ccio6t4d6ydqz55f7tt4vaiyd4)(babel-eslint@10.1.0)(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)(typescript@4.9.5)
+      gatsby: 5.9.0(patch_hash=ccio6t4d6ydqz55f7tt4vaiyd4)(babel-eslint@10.1.0)(react-dom@18.2.0)(react@18.2.0)(typescript@4.9.5)
       gatsby-core-utils: 4.9.0
       gatsby-page-utils: 3.9.0
       gatsby-plugin-utils: 4.9.0(gatsby@5.9.0)(graphql@16.6.0)
@@ -14111,7 +14111,7 @@ packages:
     peerDependencies:
       gatsby: ~2.x.x || ~3.x.x || ~4.x.x
     dependencies:
-      gatsby: 5.9.0(patch_hash=ccio6t4d6ydqz55f7tt4vaiyd4)(babel-eslint@10.1.0)(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)(typescript@4.9.5)
+      gatsby: 5.9.0(patch_hash=ccio6t4d6ydqz55f7tt4vaiyd4)(babel-eslint@10.1.0)(react-dom@18.2.0)(react@18.2.0)(typescript@4.9.5)
       lodash.get: 4.4.2
       lodash.uniq: 4.5.0
     dev: false
@@ -14129,7 +14129,7 @@ packages:
       '@babel/preset-typescript': 7.21.4(@babel/core@7.21.4)
       '@babel/runtime': 7.21.0
       babel-plugin-remove-graphql-queries: 5.9.0(@babel/core@7.21.4)(gatsby@5.9.0)
-      gatsby: 5.9.0(patch_hash=ccio6t4d6ydqz55f7tt4vaiyd4)(babel-eslint@10.1.0)(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)(typescript@4.9.5)
+      gatsby: 5.9.0(patch_hash=ccio6t4d6ydqz55f7tt4vaiyd4)(babel-eslint@10.1.0)(react-dom@18.2.0)(react@18.2.0)(typescript@4.9.5)
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -14144,7 +14144,7 @@ packages:
       '@babel/runtime': 7.21.0
       fastq: 1.15.0
       fs-extra: 11.1.1
-      gatsby: 5.9.0(patch_hash=ccio6t4d6ydqz55f7tt4vaiyd4)(babel-eslint@10.1.0)(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)(typescript@4.9.5)
+      gatsby: 5.9.0(patch_hash=ccio6t4d6ydqz55f7tt4vaiyd4)(babel-eslint@10.1.0)(react-dom@18.2.0)(react@18.2.0)(typescript@4.9.5)
       gatsby-core-utils: 4.9.0
       gatsby-sharp: 1.9.0
       graphql: 16.6.0
@@ -14154,7 +14154,7 @@ packages:
       mime: 3.0.0
     dev: false
 
-  /gatsby-react-router-scroll@6.9.0(@gatsbyjs/reach-router@2.0.1)(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517):
+  /gatsby-react-router-scroll@6.9.0(@gatsbyjs/reach-router@2.0.1)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-HVhAaze2DUpE5F31fgKTTPfLdP2uOA9W9J8bYTccbLvdh21F4EmARiwBX4D6z1FwA5MaoJKw9EqeS6QmTWx93Q==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
@@ -14163,13 +14163,13 @@ packages:
       react-dom: ^18.0.0 || ^0.0.0
     dependencies:
       '@babel/runtime': 7.21.0
-      '@gatsbyjs/reach-router': 2.0.1(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)
+      '@gatsbyjs/reach-router': 2.0.1(react-dom@18.2.0)(react@18.2.0)
       prop-types: 15.8.1
-      react: 0.0.0-experimental-5309f1028-20230517
-      react-dom: 0.0.0-experimental-5309f1028-20230517(react@0.0.0-experimental-5309f1028-20230517)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /gatsby-script@2.9.0(@gatsbyjs/reach-router@2.0.1)(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517):
+  /gatsby-script@2.9.0(@gatsbyjs/reach-router@2.0.1)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-9AWRBIDgahdurDjOnlNnEeiQLPzSpeec4zESDNRJXHBeGgsqq/i8k5nVf19dp0zF5iaYH6EdxMk7nAedTYX80w==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
@@ -14177,9 +14177,9 @@ packages:
       react: ^18.0.0 || ^0.0.0
       react-dom: ^18.0.0 || ^0.0.0
     dependencies:
-      '@gatsbyjs/reach-router': 2.0.1(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)
-      react: 0.0.0-experimental-5309f1028-20230517
-      react-dom: 0.0.0-experimental-5309f1028-20230517(react@0.0.0-experimental-5309f1028-20230517)
+      '@gatsbyjs/reach-router': 2.0.1(react-dom@18.2.0)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
   /gatsby-sharp@1.9.0:
@@ -14223,7 +14223,7 @@ packages:
       - supports-color
     dev: false
 
-  /gatsby@5.9.0(patch_hash=ccio6t4d6ydqz55f7tt4vaiyd4)(babel-eslint@10.1.0)(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)(typescript@4.9.5):
+  /gatsby@5.9.0(patch_hash=ccio6t4d6ydqz55f7tt4vaiyd4)(babel-eslint@10.1.0)(react-dom@18.2.0)(react@18.2.0)(typescript@4.9.5):
     resolution: {integrity: sha512-XjKwjlscSgOZqqXCY1+Y3VX9+AyMBZMGer2xt6BxpXAz+uEHomdiVpToncka5BlrxgDYkDmx83yIBZKN9uAwiw==}
     engines: {node: '>=18.0.0'}
     hasBin: true
@@ -14241,7 +14241,7 @@ packages:
       '@babel/traverse': 7.21.4
       '@babel/types': 7.21.4
       '@builder.io/partytown': 0.7.6
-      '@gatsbyjs/reach-router': 2.0.1(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)
+      '@gatsbyjs/reach-router': 2.0.1(react-dom@18.2.0)(react@18.2.0)
       '@gatsbyjs/webpack-hot-middleware': 2.25.3
       '@graphql-codegen/add': 3.2.3(graphql@16.6.0)
       '@graphql-codegen/core': 2.6.8(graphql@16.6.0)
@@ -14316,14 +14316,14 @@ packages:
       gatsby-core-utils: 4.9.0
       gatsby-graphiql-explorer: 3.9.0
       gatsby-legacy-polyfills: 3.9.0
-      gatsby-link: 5.9.0(@gatsbyjs/reach-router@2.0.1)(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)
+      gatsby-link: 5.9.0(@gatsbyjs/reach-router@2.0.1)(react-dom@18.2.0)(react@18.2.0)
       gatsby-page-utils: 3.9.0
       gatsby-parcel-config: 1.9.0(@parcel/core@2.8.3)
       gatsby-plugin-page-creator: 5.9.0(gatsby@5.9.0)(graphql@16.6.0)
       gatsby-plugin-typescript: 5.9.0(gatsby@5.9.0)
       gatsby-plugin-utils: 4.9.0(gatsby@5.9.0)(graphql@16.6.0)
-      gatsby-react-router-scroll: 6.9.0(@gatsbyjs/reach-router@2.0.1)(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)
-      gatsby-script: 2.9.0(@gatsbyjs/reach-router@2.0.1)(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517)
+      gatsby-react-router-scroll: 6.9.0(@gatsbyjs/reach-router@2.0.1)(react-dom@18.2.0)(react@18.2.0)
+      gatsby-script: 2.9.0(@gatsbyjs/reach-router@2.0.1)(react-dom@18.2.0)(react@18.2.0)
       gatsby-telemetry: 4.9.0
       gatsby-worker: 2.9.0
       glob: 7.2.3
@@ -14366,11 +14366,11 @@ packages:
       prop-types: 15.8.1
       query-string: 6.14.1
       raw-loader: 4.0.2(webpack@5.80.0)
-      react: 0.0.0-experimental-5309f1028-20230517
+      react: 18.2.0
       react-dev-utils: 12.0.1(eslint@7.32.0)(typescript@4.9.5)(webpack@5.80.0)
-      react-dom: 0.0.0-experimental-5309f1028-20230517(react@0.0.0-experimental-5309f1028-20230517)
+      react-dom: 18.2.0(react@18.2.0)
       react-refresh: 0.14.0
-      react-server-dom-webpack: 0.0.0-experimental-c8b778b7f-20220825(react@0.0.0-experimental-5309f1028-20230517)(webpack@5.80.0)
+      react-server-dom-webpack: 0.0.0-experimental-c8b778b7f-20220825(react@18.2.0)(webpack@5.80.0)
       redux: 4.2.1
       redux-thunk: 2.4.2(redux@4.2.1)
       resolve-from: 5.0.0
@@ -17998,13 +17998,13 @@ packages:
       object-visit: 1.0.1
     dev: false
 
-  /markdown-to-jsx@7.2.0(react@0.0.0-experimental-5309f1028-20230517):
+  /markdown-to-jsx@7.2.0(react@18.2.0):
     resolution: {integrity: sha512-3l4/Bigjm4bEqjCR6Xr+d4DtM1X6vvtGsMGSjJYyep8RjjIvcWtrXBS8Wbfe1/P+atKNMccpsraESIaWVplzVg==}
     engines: {node: '>= 10'}
     peerDependencies:
       react: '>= 0.14.0'
     dependencies:
-      react: 0.0.0-experimental-5309f1028-20230517
+      react: 18.2.0
     dev: true
 
   /maxstache-stream@1.0.4:
@@ -21250,14 +21250,14 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: true
 
-  /react-colorful@5.6.1(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517):
+  /react-colorful@5.6.1(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
     dependencies:
-      react: 0.0.0-experimental-5309f1028-20230517
-      react-dom: 0.0.0-experimental-5309f1028-20230517(react@0.0.0-experimental-5309f1028-20230517)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: true
 
   /react-dev-utils@12.0.1(eslint@7.32.0)(typescript@4.9.5)(webpack@5.80.0):
@@ -21329,15 +21329,6 @@ packages:
       - supports-color
     dev: true
 
-  /react-dom@0.0.0-experimental-5309f1028-20230517(react@0.0.0-experimental-5309f1028-20230517):
-    resolution: {integrity: sha512-zMyA7Vo+JQ1AulSapio3pAMLt8l5Bmdj/ej+UVbEojXb+Tc/HXEAiQu0IBAW51aiSciZBAo+CxEHQ62Amg0eFQ==}
-    peerDependencies:
-      react: 0.0.0-experimental-5309f1028-20230517
-    dependencies:
-      loose-envify: 1.4.0
-      react: 0.0.0-experimental-5309f1028-20230517
-      scheduler: 0.0.0-experimental-5309f1028-20230517
-
   /react-dom@17.0.2(react@17.0.2):
     resolution: {integrity: sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==}
     peerDependencies:
@@ -21358,7 +21349,7 @@ packages:
       react: 18.2.0
       scheduler: 0.23.0
 
-  /react-element-to-jsx-string@15.0.0(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517):
+  /react-element-to-jsx-string@15.0.0(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-UDg4lXB6BzlobN60P8fHWVPX3Kyw8ORrTeBtClmIlGdkOOE+GYQSFvmEU5iLLpwp/6v42DINwNcwOhOLfQ//FQ==}
     peerDependencies:
       react: ^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1 || ^18.0.0
@@ -21366,8 +21357,8 @@ packages:
     dependencies:
       '@base2/pretty-print-object': 1.0.1
       is-plain-object: 5.0.0
-      react: 0.0.0-experimental-5309f1028-20230517
-      react-dom: 0.0.0-experimental-5309f1028-20230517(react@0.0.0-experimental-5309f1028-20230517)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
       react-is: 18.1.0
     dev: true
 
@@ -21375,15 +21366,15 @@ packages:
     resolution: {integrity: sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==}
     dev: false
 
-  /react-inspector@6.0.1(react@0.0.0-experimental-5309f1028-20230517):
+  /react-inspector@6.0.1(react@18.2.0):
     resolution: {integrity: sha512-cxKSeFTf7jpSSVddm66sKdolG90qURAX3g1roTeaN6x0YEbtWc8JpmFN9+yIqLNH2uEkYerWLtJZIXRIFuBKrg==}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0 || ^18.0.0
     dependencies:
-      react: 0.0.0-experimental-5309f1028-20230517
+      react: 18.2.0
     dev: true
 
-  /react-intl@6.4.1(react@0.0.0-experimental-5309f1028-20230517)(typescript@5.0.4):
+  /react-intl@6.4.1(react@18.2.0)(typescript@5.0.4):
     resolution: {integrity: sha512-/aT5595AEMZ+Pjmt8W2R5/ZkYJmyyd6jTzHzqhJ1LnfeG36+N5huBtykxYhHqLc1BrIRQ1fTX1orYC0Ej5ojtg==}
     peerDependencies:
       react: ^16.6.0 || 17 || 18
@@ -21401,7 +21392,7 @@ packages:
       '@types/react': 18.2.0
       hoist-non-react-statics: 3.3.2
       intl-messageformat: 10.3.4
-      react: 0.0.0-experimental-5309f1028-20230517
+      react: 18.2.0
       tslib: 2.5.0
       typescript: 5.0.4
     dev: false
@@ -21424,7 +21415,7 @@ packages:
     resolution: {integrity: sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==}
     engines: {node: '>=0.10.0'}
 
-  /react-server-dom-webpack@0.0.0-experimental-c8b778b7f-20220825(react@0.0.0-experimental-5309f1028-20230517)(webpack@5.80.0):
+  /react-server-dom-webpack@0.0.0-experimental-c8b778b7f-20220825(react@18.2.0)(webpack@5.80.0):
     resolution: {integrity: sha512-JyCjbp6ZvkH/T0EuVPdceYlC8u5WqWDSJr2KxDvc81H2eJ+7zYUN++IcEycnR2F+HmER8QVgxfotnIx352zi+w==}
     engines: {node: '>=0.10.0'}
     peerDependencies:
@@ -21434,15 +21425,9 @@ packages:
       acorn: 6.4.2
       loose-envify: 1.4.0
       neo-async: 2.6.2
-      react: 0.0.0-experimental-5309f1028-20230517
+      react: 18.2.0
       webpack: 5.80.0
     dev: false
-
-  /react@0.0.0-experimental-5309f1028-20230517:
-    resolution: {integrity: sha512-Tortjv6aW9+FFVPzdYknsVNCniiN8W0xHISyU2/6fsKmjaiIhe5KPDj66xNQN6r4BWnfkGzjBbk3pPkIYzmBiQ==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      loose-envify: 1.4.0
 
   /react@17.0.2:
     resolution: {integrity: sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==}
@@ -22093,11 +22078,6 @@ packages:
 
   /safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
-
-  /scheduler@0.0.0-experimental-5309f1028-20230517:
-    resolution: {integrity: sha512-0lPWnDRh10IpgFbG3gfRm/XqCidMBKEZtoXBWsMMpW0eVEEU05tfRHPzxaT8A9kFtuKThhBI4XAZjcxUzUx40w==}
-    dependencies:
-      loose-envify: 1.4.0
 
   /scheduler@0.20.2:
     resolution: {integrity: sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==}
@@ -24548,24 +24528,16 @@ packages:
       react: 18.2.0
     dev: true
 
-  /use-resize-observer@9.1.0(react-dom@0.0.0-experimental-5309f1028-20230517)(react@0.0.0-experimental-5309f1028-20230517):
+  /use-resize-observer@9.1.0(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-R25VqO9Wb3asSD4eqtcxk8sJalvIOYBqS8MNZlpDSQ4l4xMQxC/J7Id9HoTqPq8FwULIn0PVW+OAqF2dyYbjow==}
     peerDependencies:
       react: 16.8.0 - 18
       react-dom: 16.8.0 - 18
     dependencies:
       '@juggle/resize-observer': 3.4.0
-      react: 0.0.0-experimental-5309f1028-20230517
-      react-dom: 0.0.0-experimental-5309f1028-20230517(react@0.0.0-experimental-5309f1028-20230517)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: true
-
-  /use-sync-external-store@1.2.0(react@0.0.0-experimental-5309f1028-20230517):
-    resolution: {integrity: sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-    dependencies:
-      react: 0.0.0-experimental-5309f1028-20230517
-    dev: false
 
   /use-sync-external-store@1.2.0(react@18.2.0):
     resolution: {integrity: sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==}
@@ -25791,7 +25763,7 @@ packages:
       readable-stream: 3.6.2
     dev: false
 
-  /zustand@4.3.6(react@0.0.0-experimental-5309f1028-20230517):
+  /zustand@4.3.6(react@18.2.0):
     resolution: {integrity: sha512-6J5zDxjxLE+yukC2XZWf/IyWVKnXT9b9HUv09VJ/bwGCpKNcaTqp7Ws28Xr8jnbvnZcdRaidztAPsXFBIqufiw==}
     engines: {node: '>=12.7.0'}
     peerDependencies:
@@ -25803,8 +25775,8 @@ packages:
       react:
         optional: true
     dependencies:
-      react: 0.0.0-experimental-5309f1028-20230517
-      use-sync-external-store: 1.2.0(react@0.0.0-experimental-5309f1028-20230517)
+      react: 18.2.0
+      use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false
 
   /zwitch@2.0.4:


### PR DESCRIPTION
As long as Gatsby RSC is not stable, we can keep the latest stable
react version. We should wait for Gatsby RSC to be stable.