### PR TITLE
fix(gatsby): supress scroll on search update

### DIFF
--- a/apps/website/gatsby-browser.js
+++ b/apps/website/gatsby-browser.js
@@ -1,1 +1,0 @@
-import './styles.css';

--- a/apps/website/gatsby-browser.ts
+++ b/apps/website/gatsby-browser.ts
@@ -1,0 +1,16 @@
+import './styles.css';
+
+import { GatsbyBrowser } from 'gatsby';
+
+export const shouldUpdateScroll: GatsbyBrowser['shouldUpdateScroll'] = (
+  args,
+) => {
+  // Tell Gatsby to only update scroll position if the pathname or hash has changed.
+  // If only the search has changed (e.g. when a search form is submitted),
+  // the scroll position should remain the same.
+  const current = args.routerProps.location;
+  const previous = args.prevRouterProps?.location;
+  return (
+    current.pathname !== previous?.pathname || current.hash !== previous?.hash
+  );
+};


### PR DESCRIPTION
## Description of changes

Instruct Gatsby to only update scroll position when path or hash change.

## Motivation and context

When a filter form is submitted, that only updates the search part of the url, scroll position should not change to avoid a "jump back to top" when filtering lists.

## How has this been tested?

- [x] Manually
- [ ] Unit tests
- [ ] Integration tests