### PR TITLE
chore: make it possible to run docker on mac

### DIFF
--- a/.lagoon/Dockerfile
+++ b/.lagoon/Dockerfile
@@ -111,8 +111,8 @@ RUN apk add --no-cache sqlite curl
 
 RUN npm install -g pnpm@8.6.0
 ENV DENO_INSTALL="/home/.deno"
-RUN curl -fsSL https://deno.land/x/install/install.sh | sh
-RUN ln -s /home/.deno/bin/deno /usr/local/bin/deno
+RUN if [ "$(uname -m)" != "aarch64" ]; then curl -fsSL https://deno.land/x/install/install.sh | sh; else echo "Skipping Deno installation"; fi
+RUN if [ "$(uname -m)" != "aarch64" ]; then ln -s /home/.deno/bin/deno /usr/local/bin/deno; fi
 
 COPY --from=builder /tmp/.deploy/website /app
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ x-volumes:
   &default-volumes
   # Define all volumes you would like to have real-time mounted into the docker containers
   volumes:
+    - ./packages/drupal:/app/web/modules/custom:delegated
     - ./apps/cms:/app:delegated
 
 x-environment:


### PR DESCRIPTION
## Motivation and context

1. Docker build was failing on Mac due to Deno not ready for ARM
2. Drupal custom modules symlink was broken inside Docker

## Description of changes

1. Don't install Deno on ARM
3. Mount Drupal custom modules

## Fun&pain from Docker

When I first added `./packages/drupal:/app/web/modules/custom:delegated` to `volumes`, I saw this:

```
[silverback-template]cli-drupal:/app$ cd web/modules/

[silverback-template]cli-drupal:/app/web/modules$ ls -lisa
total 4
87561178 0 drwxr-xr-x  5 root root  160 Aug 16 11:02 .
87561177 0 drwxr-xr-x 22 root root  704 Aug 17 11:58 ..
93491060 4 -rw-r--r--  1 root root 1757 Aug 16 11:02 README.txt
93445865 0 drwxr-xr-x 55 1000 root 1760 Aug 16 11:02 contrib
92692486 0 lrwxr-xr-x  1 root root   27 Aug 15 06:51 custom -> ../../../../packages/drupal
```

So `custom` was still a link and, considering that `../..` is already the root, it was definitely a broken link.

So I tried other ways to deal with it. Wasted some time. And when I almost gave up...
```
[silverback-template]cli-drupal:/app$ cd web/modules/

[silverback-template]cli-drupal:/app/web/modules$ ls -lisa
total 4
87561178 0 drwxr-xr-x  5 root root  160 Aug 16 11:02 .
87561177 0 drwxr-xr-x 22 root root  704 Aug 17 11:58 ..
93491060 4 -rw-r--r--  1 root root 1757 Aug 16 11:02 README.txt
93445865 0 drwxr-xr-x 55 1000 root 1760 Aug 16 11:02 contrib
92692486 0 lrwxr-xr-x  1 root root   27 Aug 15 06:51 custom -> ../../../../packages/drupal

[silverback-template]cli-drupal:/app/web/modules$ cd custom

[silverback-template]cli-drupal:/app/web/modules/custom$ ls
README.md  custom  custom_heavy  field_chart  gutenberg_blocks	test_content  translation_notification	wb_breadcrumbs

[silverback-template]cli-drupal:/app/web/modules/custom$ cd ..

[silverback-template]cli-drupal:/app/web/modules$ cd ../../../../packages/drupal

[silverback-template]cli-drupal:/packages/drupal$
```

AAAAAAAAaaaaa!!!! Docker made this broken link working somehow 🤷 So it was working from the very beginning, I just did not believe it 🤦 

## How has this been tested?

- [x] Manually
- [ ] Unit tests
- [ ] Integration tests