### PR TITLE
feat: add sourcing types to schema

### DIFF
--- a/packages/schema/.swcrc
+++ b/packages/schema/.swcrc
@@ -3,7 +3,7 @@
   "jsc": {
     "parser": {
       "syntax": "typescript"
-    },
+    }
   },
   "module": {
     "type": "es6"

--- a/packages/schema/codegen.ts
+++ b/packages/schema/codegen.ts
@@ -1,5 +1,17 @@
 import type { CodegenConfig } from '@graphql-codegen/cli';
 
+const common = {
+  enumsAsConst: true,
+  maybeValue: 'T | undefined',
+  strictScalars: true,
+  scalars: {
+    Markup: '@amazeelabs/scalars#Markup',
+    Url: '@amazeelabs/scalars#Url',
+    ImageSource: '@amazeelabs/scalars#ImageSource',
+  },
+  withObjectType: true,
+};
+
 const config: CodegenConfig = {
   schema: 'src/schema.graphqls',
   documents: ['src/fragments/**/*.gql', 'src/operations/**/*.gql'],
@@ -19,26 +31,29 @@ const config: CodegenConfig = {
     // - All operations as typed id's
     'src/generated/index.ts': {
       plugins: [
-        {
-          typescript: {
-            enumsAsConst: true,
-          },
-        },
-        `typescript-operations`,
+        'typescript',
+        'typescript-operations',
         '@amazeelabs/codegen-operation-ids',
       ],
       config: {
-        maybeValue: 'T | undefined',
-        strictScalars: true,
-        scalars: {
-          Markup: '@amazeelabs/scalars#Markup',
-          Url: '@amazeelabs/scalars#Url',
-          ImageSource: '@amazeelabs/scalars#ImageSource',
-        },
-        withObjectType: true,
+        ...common,
         // Only add __typename to types if it is explicitly specified in the
         // query.
         skipTypename: true,
+      },
+    },
+    // Source type definitions.
+    // All graphql schema types, suffixed with `Source` and with required
+    // type names. Used for validating incoming data, e.g. from Decap.
+    'src/generated/source.ts': {
+      plugins: [`typescript`],
+      config: {
+        ...common,
+        typesSuffix: 'Source',
+        // In source types we always want an enforced __typename, so unions and
+        // interfaces can be resolved automatically.
+        skipTypename: false,
+        nonOptionalTypename: true,
       },
     },
   },

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -3,12 +3,33 @@
   "description": "GraphQL schema and operation definitions.",
   "type": "module",
   "main": "build/index.js",
-  "types": "src/index.ts",
+  "types": "build/index.d.ts",
   "private": true,
   "sideEffects": false,
+  "exports": {
+    ".": [
+      "./build/index.js"
+    ],
+    "./source": [
+      "./build/generated/source.js"
+    ],
+    "./operations": [
+      "./build/operations.json"
+    ]
+  },
+  "typesVersions": {
+    "*": {
+      ".": [
+        "build/index.d.ts"
+      ],
+      "/source": [
+        "build/generated/source.d.ts"
+      ]
+    }
+  },
   "scripts": {
     "watch": "graphql-codegen --verbose --watch",
-    "prep": "graphql-codegen --verbose && swc ./src -d ./build"
+    "prep": "graphql-codegen --verbose && swc ./src -d ./build && tsc --emitDeclarationOnly"
   },
   "devDependencies": {
     "@amazeelabs/codegen-gatsby-fragments": "^1.1.8",

--- a/packages/schema/src/generated/.gitignore
+++ b/packages/schema/src/generated/.gitignore
@@ -1,1 +1,2 @@
 index.ts
+source.ts

--- a/packages/schema/tsconfig.json
+++ b/packages/schema/tsconfig.json
@@ -4,6 +4,9 @@
     "strict": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "noEmit": true
-  }
+    "declaration": true,
+    "declarationDir": "build",
+    "outDir": "build"
+  },
+  "include": ["src"]
 }


### PR DESCRIPTION
## Description of changes

Add a new configuration to codegen that adds `src/generated/source.ts`.
These are type definitions for creating data that is sourced into the graphql schema.
In contrast to the standard graphql types, source types have a `Source` suffix
and enforce a `__typename` field.

## Motivation and context

Typing assistance for sourcing arbitrary data into Gatsby (e.g. from Decap).

## How has this been tested?

- [x] Manually
- [ ] Unit tests
- [ ] Integration tests
