### PR TITLE
Page transitions

### DIFF
--- a/apps/website/gatsby-config.js
+++ b/apps/website/gatsby-config.js
@@ -33,6 +33,7 @@ module.exports = {
   },
   plugins: [
     'gatsby-plugin-pnpm',
+    'gatsby-plugin-layout',
     {
       resolve: '@amazeelabs/gatsby-source-silverback',
       options: {

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -16,6 +16,7 @@
     "gatsby-plugin-pnpm": "^1.2.10",
     "gatsby-plugin-robots-txt": "^1.8.0",
     "gatsby-plugin-sitemap": "^6.11.0",
+    "gatsby-plugin-layout": "^4.12.0",
     "netlify-cli": "^15.7.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/apps/website/src/layouts/index.tsx
+++ b/apps/website/src/layouts/index.tsx
@@ -1,7 +1,8 @@
-import { Locale, NavigationFragment } from '@custom/schema';
+import { SilverbackPageContext } from '@amazeelabs/gatsby-source-silverback';
+import { NavigationFragment } from '@custom/schema';
 import { IntlProvider } from '@custom/ui/intl';
 import { Frame } from '@custom/ui/routes/Frame';
-import { graphql, useStaticQuery } from 'gatsby';
+import { graphql, useStaticQuery, WrapPageElementNodeArgs } from 'gatsby';
 import React, { PropsWithChildren } from 'react';
 
 function useFrameQuery() {
@@ -34,15 +35,17 @@ function useFrameQuery() {
   `);
 }
 
-export function Wrapper({
+export default function Layout({
   children,
-  locale = 'en',
-}: PropsWithChildren<{ locale?: Locale }>) {
+  pageContext: { locale },
+}: PropsWithChildren<
+  WrapPageElementNodeArgs<any, SilverbackPageContext>['props']
+>) {
   const data = useFrameQuery();
   const main = locale === 'de' ? data.main_de : data.main_en;
   const footer = locale === 'de' ? data.footer_de : data.footer_en;
   return (
-    <IntlProvider locale={locale}>
+    <IntlProvider locale={locale || 'en'}>
       <Frame
         header={{ mainNavigation: main }}
         footer={{ footerNavigation: footer }}

--- a/apps/website/src/pages/404.tsx
+++ b/apps/website/src/pages/404.tsx
@@ -7,7 +7,6 @@ import {
   LanguageNegotiator,
   LanguageNegotiatorContent,
 } from '../utils/language-negotiator';
-import { Wrapper } from '../utils/wrapper';
 
 export const query = graphql`
   query NotFoundPage {
@@ -40,16 +39,14 @@ export function Head() {
 
 export default function Index({ data }: PageProps<NotFoundPageQuery>) {
   return (
-    <Wrapper>
-      <LanguageNegotiator defaultLanguage={'en'}>
-        {data.websiteSettings?.notFoundPage?.translations?.map(
-          ({ locale, ...page }) => (
-            <LanguageNegotiatorContent key={locale} language={locale}>
-              <Page page={page} />
-            </LanguageNegotiatorContent>
-          ),
-        )}
-      </LanguageNegotiator>
-    </Wrapper>
+    <LanguageNegotiator defaultLanguage={'en'}>
+      {data.websiteSettings?.notFoundPage?.translations?.map(
+        ({ locale, ...page }) => (
+          <LanguageNegotiatorContent key={locale} language={locale}>
+            <Page page={page} />
+          </LanguageNegotiatorContent>
+        ),
+      )}
+    </LanguageNegotiator>
   );
 }

--- a/apps/website/src/pages/__preview/page.tsx
+++ b/apps/website/src/pages/__preview/page.tsx
@@ -1,16 +1,11 @@
 import React from 'react';
 
 import PagePreview from '../../preview/page';
-import { Wrapper } from '../../utils/wrapper';
 
 export function Head() {
   return <meta title="Page preview" />;
 }
 
 export default function PagePreviewTemplate() {
-  return (
-    <Wrapper>
-      <PagePreview />
-    </Wrapper>
-  );
+  return <PagePreview />;
 }

--- a/apps/website/src/pages/content-hub.tsx
+++ b/apps/website/src/pages/content-hub.tsx
@@ -1,16 +1,10 @@
 import { ContentHub } from '@custom/ui/routes/ContentHub';
 import React from 'react';
 
-import { Wrapper } from '../utils/wrapper';
-
 export function Head() {
   return <meta title="Page not found" />;
 }
 
 export default function ContentHubPage() {
-  return (
-    <Wrapper>
-      <ContentHub pageSize={6} />
-    </Wrapper>
-  );
+  return <ContentHub pageSize={6} />;
 }

--- a/apps/website/src/templates/page.tsx
+++ b/apps/website/src/templates/page.tsx
@@ -1,10 +1,8 @@
 import { SilverbackPageContext } from '@amazeelabs/gatsby-source-silverback';
-import { Locale, PageFragment } from '@custom/schema';
+import { PageFragment } from '@custom/schema';
 import { Page } from '@custom/ui/routes/Page';
 import { graphql, HeadProps, PageProps } from 'gatsby';
 import React from 'react';
-
-import { Wrapper } from '../utils/wrapper';
 
 export const query = graphql`
   query PageTemplate($remoteId: String!) {
@@ -48,11 +46,6 @@ export function Head({ data }: HeadProps<PageTemplateQuery>) {
 
 export default function PageTemplate({
   data,
-  pageContext,
 }: PageProps<PageTemplateQuery, SilverbackPageContext>) {
-  return (
-    <Wrapper locale={(pageContext.locale || 'en') as Locale}>
-      <Page page={data.page} />
-    </Wrapper>
-  );
+  return <Page page={data.page} />;
 }

--- a/packages/ui/src/components/Molecules/PageTransition.tsx
+++ b/packages/ui/src/components/Molecules/PageTransition.tsx
@@ -1,0 +1,33 @@
+import { motion, useReducedMotion } from 'framer-motion';
+import React, { PropsWithChildren, useEffect } from 'react';
+
+import { Messages, readMessages } from './Messages';
+
+export function PageTransition({ children }: PropsWithChildren) {
+  const [messages, setMessages] = React.useState<Array<string>>([]);
+  useEffect(() => {
+    setMessages(readMessages());
+  }, []);
+  return useReducedMotion() ? (
+    <main id="main-content">
+      <Messages messages={messages} />
+      {children}
+    </main>
+  ) : (
+    <motion.main
+      id="main-content"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      transition={{
+        type: 'spring',
+        mass: 0.35,
+        stiffness: 75,
+        duration: 0.3,
+      }}
+    >
+      <Messages messages={messages} />
+      {children}
+    </motion.main>
+  );
+}

--- a/packages/ui/src/components/Routes/ContentHub.tsx
+++ b/packages/ui/src/components/Routes/ContentHub.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
 
+import { PageTransition } from '../Molecules/PageTransition';
 import { ContentHub as ContentHubOrganism } from '../Organisms/ContentHub';
 
 export function ContentHub(props: { pageSize: number }) {
-  return <ContentHubOrganism pageSize={props.pageSize} />;
+  return (
+    <PageTransition>
+      <ContentHubOrganism pageSize={props.pageSize} />
+    </PageTransition>
+  );
 }

--- a/packages/ui/src/components/Routes/Frame.tsx
+++ b/packages/ui/src/components/Routes/Frame.tsx
@@ -1,6 +1,6 @@
-import React, { ComponentProps, PropsWithChildren, useEffect } from 'react';
+import { AnimatePresence, useReducedMotion } from 'framer-motion';
+import React, { ComponentProps, PropsWithChildren } from 'react';
 
-import { Messages, readMessages } from '../Molecules/Messages';
 import { Footer } from '../Organisms/Footer';
 import Header from '../Organisms/Header';
 
@@ -10,16 +10,17 @@ export function Frame(
     footer: ComponentProps<typeof Footer>;
   }>,
 ) {
-  const [messages, setMessages] = React.useState<Array<string>>([]);
-  useEffect(() => {
-    setMessages(readMessages());
-  }, []);
   return (
     <div>
       <Header {...props.header} />
       <main>
-        <Messages messages={messages} />
-        {props.children}
+        {useReducedMotion() ? (
+          <>{props.children}</>
+        ) : (
+          <AnimatePresence mode="wait" initial={false}>
+            {props.children}
+          </AnimatePresence>
+        )}
       </main>
       <Footer {...props.footer} />
     </div>

--- a/packages/ui/src/components/Routes/Page.tsx
+++ b/packages/ui/src/components/Routes/Page.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 
 import { isTruthy } from '../../utils/isTruthy';
 import { UnreachableCaseError } from '../../utils/unreachable-case-error';
+import { PageTransition } from '../Molecules/PageTransition';
 import { BlockForm } from '../Organisms/PageContent/BlockForm';
 import { BlockMarkup } from '../Organisms/PageContent/BlockMarkup';
 import { BlockMedia } from '../Organisms/PageContent/BlockMedia';
@@ -10,26 +11,28 @@ import { PageHero } from '../Organisms/PageHero';
 
 export function Page(props: { page: PageFragment }) {
   return (
-    <div>
-      {props.page.hero ? <PageHero {...props.page.hero} /> : null}
-      <div className="bg-white py-12 px-6 lg:px-8">
-        <div className="mx-auto max-w-3xl text-base leading-7 text-gray-700">
-          <div className="mt-10">
-            {props.page?.content?.filter(isTruthy).map((block, index) => {
-              switch (block.__typename) {
-                case 'BlockMedia':
-                  return <BlockMedia key={index} {...block} />;
-                case 'BlockMarkup':
-                  return <BlockMarkup key={index} {...block} />;
-                case 'BlockForm':
-                  return <BlockForm key={index} {...block} />;
-                default:
-                  throw new UnreachableCaseError(block);
-              }
-            })}
+    <PageTransition>
+      <div>
+        {props.page.hero ? <PageHero {...props.page.hero} /> : null}
+        <div className="bg-white py-12 px-6 lg:px-8">
+          <div className="mx-auto max-w-3xl text-base leading-7 text-gray-700">
+            <div className="mt-10">
+              {props.page?.content?.filter(isTruthy).map((block, index) => {
+                switch (block.__typename) {
+                  case 'BlockMedia':
+                    return <BlockMedia key={index} {...block} />;
+                  case 'BlockMarkup':
+                    return <BlockMarkup key={index} {...block} />;
+                  case 'BlockForm':
+                    return <BlockForm key={index} {...block} />;
+                  default:
+                    throw new UnreachableCaseError(block);
+                }
+              })}
+            </div>
           </div>
         </div>
       </div>
-    </div>
+    </PageTransition>
   );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,6 +192,9 @@ importers:
       gatsby:
         specifier: ^5.11.0
         version: 5.11.0(babel-eslint@10.1.0)(react-dom@18.2.0)(react@18.2.0)(typescript@4.9.5)
+      gatsby-plugin-layout:
+        specifier: ^4.12.0
+        version: 4.12.0(gatsby@5.11.0)
       gatsby-plugin-manifest:
         specifier: ^5.11.0
         version: 5.11.0(gatsby@5.11.0)(graphql@16.7.1)
@@ -17417,6 +17420,16 @@ packages:
       '@parcel/runtime-js': 2.8.3(@parcel/core@2.8.3)
       '@parcel/transformer-js': 2.8.3(@parcel/core@2.8.3)
       '@parcel/transformer-json': 2.8.3(@parcel/core@2.8.3)
+    dev: false
+
+  /gatsby-plugin-layout@4.12.0(gatsby@5.11.0):
+    resolution: {integrity: sha512-MTLmay29gGvRu/v/6dNhD7tg2T6AMaUE1HAOGnCFo+oHZFRh7CMdte3RoGZUYi2NT49VPsADsDWI4a0JyI+oRw==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      gatsby: ^5.0.0-next
+    dependencies:
+      '@babel/runtime': 7.22.5
+      gatsby: 5.11.0(babel-eslint@10.1.0)(react-dom@18.2.0)(react@18.2.0)(typescript@4.9.5)
     dev: false
 
   /gatsby-plugin-manifest@5.11.0(gatsby@5.11.0)(graphql@16.7.1):

--- a/tests/e2e/specs/links.spec.ts
+++ b/tests/e2e/specs/links.spec.ts
@@ -9,10 +9,12 @@ test.describe('links', () => {
     await page.getByRole('link', { name: 'link to page' }).click();
     await page.waitForURL(websiteUrl('/en/privacy'));
 
-    await page.goBack();
+    await page.goto(websiteUrl('/en/page-links'));
 
     const downloadPromise = page.waitForEvent('download');
-    await page.getByRole('link', { name: 'link to file' }).click();
+    await page
+      .getByRole('link', { name: 'link to file', includeHidden: true })
+      .click();
     const download = await downloadPromise;
     expect(download.url()).toBe(
       websiteUrl('/sites/default/files/2023-04/document_docx.docx'),


### PR DESCRIPTION
## Description of changes

Switch the current Gatsby "Wrapper" component to a layout applied
by `gatsby-plugin-layout` and use it to implement a simple fade page
transition.

## Motivation and context

Showcase page transitions.

## How has this been tested?

- [x] Manually
- [ ] Unit tests
- [x] Integration tests
