### PR TITLE
feat: add lang attribute to html tag

### DIFF
--- a/apps/website/gatsby-ssr.ts
+++ b/apps/website/gatsby-ssr.ts
@@ -1,0 +1,27 @@
+import './styles.css';
+
+import { Locale } from '@custom/schema';
+import { GatsbySSR } from 'gatsby';
+
+export const onRenderBody: GatsbySSR['onRenderBody'] = ({
+  setHtmlAttributes,
+  pathname,
+}) => {
+  const locales = Object.values(Locale);
+  if (locales.length === 1) {
+    // Single-language project.
+    setHtmlAttributes({
+      lang: locales[0],
+    });
+  } else {
+    // Multi-language project.
+    const prefix = pathname.split('/')[1];
+    if (locales.includes(prefix as Locale)) {
+      setHtmlAttributes({
+        lang: prefix,
+      });
+    } else {
+      // We don't know the language.
+    }
+  }
+};

--- a/tests/e2e/specs/metatags.spec.ts
+++ b/tests/e2e/specs/metatags.spec.ts
@@ -18,3 +18,15 @@ test('Metatags on Basic page', async ({ page }) => {
     pageUrl,
   );
 });
+
+test('HTML lang attribute', async ({ page }) => {
+  await page.goto(websiteUrl('/en'));
+  await expect(page.locator('html')).toHaveAttribute('lang', 'en');
+  await page.goto(websiteUrl('/de'));
+  await expect(page.locator('html')).toHaveAttribute('lang', 'de');
+
+  await page.goto(websiteUrl('/en/imprint'));
+  await expect(page.locator('html')).toHaveAttribute('lang', 'en');
+  await page.goto(websiteUrl('/de/impressum'));
+  await expect(page.locator('html')).toHaveAttribute('lang', 'de');
+});


### PR DESCRIPTION
## Motivation and context

It was noticed that `html` tag has no `lang` attribute.

## How has this been tested?

- [ ] Manually
- [ ] Unit tests
- [x] Integration tests