### PR TITLE
SLB-260: split prep tasks

### DIFF
--- a/.idea/watcherTasks.xml
+++ b/.idea/watcherTasks.xml
@@ -2,7 +2,7 @@
 <project version="4">
   <component name="ProjectTasksOptions">
     <TaskOptions isEnabled="true">
-      <option name="arguments" value="prep" />
+      <option name="arguments" value="turbo prep" />
       <option name="checkSyntaxErrors" value="true" />
       <option name="description" />
       <option name="exitCodeBehavior" value="ERROR" />

--- a/apps/decap/package.json
+++ b/apps/decap/package.json
@@ -7,7 +7,6 @@
   "type": "module",
   "scripts": {
     "dev": "vite --host",
-    "prep": "pnpm prep:vite && pnpm prep:scripts",
     "prep:vite": "vite build",
     "prep:scripts": "tsup",
     "start": "GIT_REPO_DIRECTORY=../../ pnpm netlify-cms-proxy-server",

--- a/apps/decap/turbo.json
+++ b/apps/decap/turbo.json
@@ -1,8 +1,38 @@
 {
-  "extends": ["//"],
+  "$schema": "https://turborepo.org/schema.json",
+  "extends": [
+    "//"
+  ],
   "pipeline": {
+    "prep:vite": {
+      "dependsOn": [
+        "^prep"
+      ],
+      "inputs": [
+        "src/**",
+        "vite.config.js"
+      ],
+      "outputs": [
+        "build/**"
+      ]
+    },
+    "prep:scripts": {
+      "dependsOn": [
+        "^prep"
+      ],
+      "inputs": [
+        "src/**",
+        "tsup.config.js"
+      ],
+      "outputs": [
+        "dist/**"
+      ]
+    },
     "prep": {
-      "outputs": ["dist/**", "build/**"]
+      "dependsOn": [
+        "prep:vite",
+        "prep:scripts"
+      ]
     }
   }
 }

--- a/packages/drupal/custom/directives.graphql
+++ b/packages/drupal/custom/directives.graphql
@@ -1,9 +1,0 @@
-"""
-implementation(drupal): custom.content_hub::query
-"""
-directive @contentHub(pagination: String, query: String) on FIELD_DEFINITION
-
-"""
-implementation(drupal): custom.webform::url
-"""
-directive @webformIdToUrl(id: String!) on FIELD_DEFINITION

--- a/packages/drupal/gutenberg_blocks/.gitignore
+++ b/packages/drupal/gutenberg_blocks/.gitignore
@@ -1,4 +1,3 @@
 node_modules
-css/ui.css
 js/gutenberg_blocks.mjs
 js/gutenberg_blocks.umd.js

--- a/packages/drupal/gutenberg_blocks/package.json
+++ b/packages/drupal/gutenberg_blocks/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "vite build --watch",
-    "prep": "vite build && cp node_modules/@custom/ui/build/gutenberg.css css/ui.css",
+    "prep": "vite build",
     "test:static": "tsc --noEmit && eslint \"**/*.{ts,tsx,js,jsx}\" --ignore-path=\"./.eslintignore\""
   },
   "dependencies": {

--- a/packages/drupal/gutenberg_blocks/turbo.json
+++ b/packages/drupal/gutenberg_blocks/turbo.json
@@ -1,11 +1,20 @@
 {
-  "extends": ["//"],
+  "extends": [
+    "//"
+  ],
   "pipeline": {
     "test:static": {
-      "inputs": ["src/**"]
+      "inputs": [
+        "src/**"
+      ]
     },
     "prep": {
-      "outputs": ["js/**"]
+      "inputs": [
+        "src/**"
+      ],
+      "outputs": [
+        "js/**"
+      ]
     }
   }
 }

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -38,7 +38,9 @@
     "watch:codegen": "graphql-codegen --verbose --watch",
     "watch:swc": "swc ./src -d ./build --watch",
     "watch:tsc": "tsc --emitDeclarationOnly --watch",
-    "prep": "graphql-codegen --verbose && swc ./src -d ./build && tsc --emitDeclarationOnly"
+    "prep:codegen": "graphql-codegen --verbose",
+    "prep:scripts": "swc ./src -d ./build",
+    "prep:types": "tsc --emitDeclarationOnly"
   },
   "devDependencies": {
     "@amazeelabs/codegen-autoloader": "^1.1.3",

--- a/packages/schema/src/schema.graphql
+++ b/packages/schema/src/schema.graphql
@@ -3,6 +3,16 @@ scalar Markup @default @value(json: "\"\"")
 scalar ImageSource @default @value(json: "\"\"")
 
 """
+implementation(drupal): custom.content_hub::query
+"""
+directive @contentHub(pagination: String, query: String) on FIELD_DEFINITION
+
+"""
+implementation(drupal): custom.webform::url
+"""
+directive @webformIdToUrl(id: String!) on FIELD_DEFINITION
+
+"""
 Retrieve the properties of an image.
 TODO: Move to a shared "image" package.
 

--- a/packages/schema/turbo.json
+++ b/packages/schema/turbo.json
@@ -1,19 +1,52 @@
 {
   "$schema": "https://turborepo.org/schema.json",
-  "extends": ["//"],
+  "extends": [
+    "//"
+  ],
   "pipeline": {
-    "prep": {
-      "dependsOn": ["@custom/cms#prep:composer"],
+    "prep:codegen": {
+      "dependsOn": [
+        "@custom/cms#prep:composer"
+      ],
       "inputs": [
-        "../../apps/website/node_modules/@amazeelabs/*/directives.graphql",
-        "../../apps/cms/web/modules/contrib/*/directives.graphql",
-        "../../apps/cms/web/modules/custom/*/directives.graphql",
-        "src/**",
         "codegen.ts",
         ".graphqlrc.json",
-        "tsconfig.json"
+        "src/**/*.gql",
+        "src/**/*.graphql",
+        "src/**/*.graphqls"
       ],
-      "outputs": ["build/**"]
+      "outputs": [
+        "build/schema.graphql",
+        "build/operations.json",
+        "build/gatsby-autoload.mjs",
+        "build/drupal-autoload.json",
+        "src/generated/index.ts",
+        "src/generated/source.ts"
+      ]
+    },
+    "prep:scripts": {
+      "dependsOn": [
+        "prep:codegen"
+      ],
+      "inputs": [
+        "tsconfig.json",
+        "src/**/*.ts"
+      ],
+      "outputs": [
+        "build/**/*.js"
+      ]
+    },
+    "prep:tsc": {
+      "dependsOn": [
+        "prep:codegen"
+      ],
+      "inputs": [
+        "tsconfig.json",
+        "src/**/*.ts"
+      ],
+      "outputs": [
+        "build/**/*.d.ts"
+      ]
     }
   }
 }

--- a/packages/schema/turbo.json
+++ b/packages/schema/turbo.json
@@ -36,7 +36,7 @@
         "build/**/*.js"
       ]
     },
-    "prep:tsc": {
+    "prep:types": {
       "dependsOn": [
         "prep:codegen"
       ],
@@ -46,6 +46,12 @@
       ],
       "outputs": [
         "build/**/*.d.ts"
+      ]
+    },
+    "prep": {
+      "dependsOn": [
+        "prep:scripts",
+        "prep:types"
       ]
     }
   }


### PR DESCRIPTION
## Description of changes

Remove all occurences of `&&` in `prep` steps and replace them with Turborepo chains.

## Motivation and context

Consistent approaches for multistep builds and small performance gains due to more granular caching.

## How has this been tested?

- [ ] Manually
- [ ] Unit tests
- [ ] Integration tests
