### PR TITLE
feat(SLB-194): quick start gutenberg block generation script

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "turbo:test": "pnpm turbo:local && turbo test:unit --no-daemon --go-fallback --output-logs=new-only && turbo test:integration --no-daemon --go-fallback --output-logs=new-only --concurrency=1",
     "turbo:test:quick": "pnpm turbo:local && turbo test:unit --no-daemon --go-fallback --output-logs=new-only",
     "turbo:prep": "pnpm turbo:local && turbo prep --no-daemon --go-fallback --output-logs=new-only",
-    "turbo:prep:force": "rm -f apps/cms/web/sites/default/files/.sqlite && turbo prep --no-daemon --go-fallback --force"
+    "turbo:prep:force": "rm -f apps/cms/web/sites/default/files/.sqlite && turbo prep --no-daemon --go-fallback --force",
+    "gutenberg:generate": "pnpm run --filter \"@custom/gutenberg_blocks\" gutenberg:generate"
   },
   "private": true,
   "devDependencies": {

--- a/packages/drupal/gutenberg_blocks/README.md
+++ b/packages/drupal/gutenberg_blocks/README.md
@@ -11,6 +11,13 @@ To create a custom Gutenberg you must:
 3. Clear the cache if necessary and you should be able to add your new block
    within the Gutenberg editor.
 
+### GraphQL type-based Gutenberg block auto-generation
+To speed up the process of creating new blocks, you can use the command below to create a new block based on a GraphQL type.
+```
+pnpm gutenberg:generate <GraphQLType>
+``` 
+This will create a new block in the `src/blocks` directory, with the necessary fields and attributes already defined. You will still need to add the block to `src/index.ts` and clear the cache to see the new block in the Gutenberg editor after running this command.
+
 ### Icons
 
 You can find the icon set in use within the Gutenberg editor here:

--- a/packages/drupal/gutenberg_blocks/package.json
+++ b/packages/drupal/gutenberg_blocks/package.json
@@ -6,7 +6,7 @@
     "dev": "vite build --watch",
     "prep": "vite build",
     "test:static": "tsc --noEmit && eslint \"**/*.{ts,tsx,js,jsx}\" --ignore-path=\"./.eslintignore\"",
-    "generate-block": "node ./scripts/generate-gutenberg-block.js DemoBlock"
+    "gutenberg:generate": "node ./scripts/generate-gutenberg-block.js"
   },
   "dependencies": {
     "@types/node": "^18",

--- a/packages/drupal/gutenberg_blocks/package.json
+++ b/packages/drupal/gutenberg_blocks/package.json
@@ -5,10 +5,14 @@
   "scripts": {
     "dev": "vite build --watch",
     "prep": "vite build",
-    "test:static": "tsc --noEmit && eslint \"**/*.{ts,tsx,js,jsx}\" --ignore-path=\"./.eslintignore\""
+    "test:static": "tsc --noEmit && eslint \"**/*.{ts,tsx,js,jsx}\" --ignore-path=\"./.eslintignore\"",
+    "generate-block": "node ./scripts/generate-gutenberg-block.js DemoBlock"
   },
   "dependencies": {
+    "@types/node": "^18",
     "clsx": "^2.1.0",
+    "fs": "0.0.1-security",
+    "graphql": "16.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/drupal/gutenberg_blocks/scripts/generate-gutenberg-block.js
+++ b/packages/drupal/gutenberg_blocks/scripts/generate-gutenberg-block.js
@@ -150,7 +150,7 @@ function getGutenbergFieldBlock(attribute) {
           />`;
     case 'array':
       return ` <DrupalMediaEntity
-            className={'w-full'}
+            classname={'w-full'}
             attributes={{
               ...props.attributes,
               lockViewMode: true,

--- a/packages/drupal/gutenberg_blocks/scripts/generate-gutenberg-block.js
+++ b/packages/drupal/gutenberg_blocks/scripts/generate-gutenberg-block.js
@@ -189,5 +189,5 @@ const [, , typeName] = process.argv;
 if (typeName) {
   generateGutenbergBlockCode(typeName);
 } else {
-  console.error('Usage: node generate-gutenberg-block.js <GraphQLType>');
+  console.error('Usage: pnpm run generate-block <GraphQLType>');
 }

--- a/packages/drupal/gutenberg_blocks/scripts/generate-gutenberg-block.js
+++ b/packages/drupal/gutenberg_blocks/scripts/generate-gutenberg-block.js
@@ -1,0 +1,193 @@
+const fs = require('fs');
+const { parse } = require('graphql');
+const { readFileSync } = require('fs');
+
+// Relative path from package.json file to the schema file.
+const schema = readFileSync('../../schema/src/schema.graphql', 'utf-8');
+
+const ast = parse(schema);
+
+const typingMap = {
+  String: 'string',
+  Markup: 'string',
+  Int: 'number',
+  MediaImage: 'array',
+  ImageSource: 'array',
+  Url: 'string',
+};
+
+function generateGutenbergBlockCode(typeName) {
+  for (const typeDefinition of ast.definitions) {
+    if (
+      typeDefinition.kind === 'ObjectTypeDefinition' &&
+      typeDefinition.name.value === typeName
+    ) {
+      const blockName = typeDefinition.name.value;
+      const gutenbergBlockMachineName = toKebabCase(blockName);
+
+      const attributes = typeDefinition.fields.map((field) => {
+        const fieldType = getFieldType(field);
+        return {
+          name: ['ImageSource', 'MediaImage'].includes(fieldType)
+            ? 'mediaEntityIds'
+            : field.name.value,
+          type: typingMap[fieldType],
+        };
+      });
+
+      // Generate code for the Gutenberg block based on attributes.
+      const blockCode = generateBlockCode(
+        gutenbergBlockMachineName,
+        attributes,
+      );
+
+      // Write the generated code to a file.
+      const filePath = `./src/blocks/${gutenbergBlockMachineName}.tsx`; // Output file path
+      fs.writeFileSync(filePath, blockCode);
+
+      console.log(`Generated Gutenberg block for ${blockName} in ${filePath}`);
+      return;
+    }
+  }
+
+  console.error(`GraphQL type "${typeName}" not found in the schema.`);
+}
+
+function generateBlockCode(blockName, attributes) {
+  if (!attributes) {
+    return '';
+  }
+
+  const titleCaseTitle = toTitleCase(blockName);
+  // The file template for the Gutenberg block.
+  return `import React, { Fragment } from 'react';
+import {
+  InspectorControls,
+  RichText,
+} from 'wordpress__block-editor';
+import { registerBlockType } from 'wordpress__blocks';
+import { PanelBody } from 'wordpress__components';
+import { compose, withState } from 'wordpress__compose';
+${
+  attributes.find((attribute) => attribute.type === 'array') &&
+  `import { dispatch } from 'wordpress__data';
+
+import { DrupalMediaEntity } from '../utils/drupal-media';`
+}
+
+// @ts-ignore
+const { t: __ } = Drupal;
+ // @ts-ignore
+registerBlockType('custom/${blockName}', {
+  title: '${titleCaseTitle}',
+  icon: 'text',
+  category: 'common',
+  attributes: {
+    ${attributes.filter((attribute) => attribute.type)
+      .map(
+        (attribute) =>
+          `${attribute.name}: {
+      type: '${attribute.type}'
+    }`,
+      )
+      .join(',\n\t\t')}
+  }, 
+  // @ts-ignore
+  edit: compose(withState())((props) => {
+    const { attributes, setAttributes } = props;
+    
+    // Set default values this way so that values get saved in the block's attributes.
+    //props.setAttributes({
+    //  isQuote:
+    //    props.attributes.isQuote === undefined
+    //      ? false
+    //      : props.attributes.isQuote,
+    //});
+    
+    return (
+      <Fragment>
+        <InspectorControls>
+          <PanelBody title={__('Block settings')}>  
+            <p>Block settings</p>
+          </PanelBody>
+        </InspectorControls>
+        <div className={'container-wrapper'}>
+          <div className={'container-label'}>{__('${titleCaseTitle}')}</div>
+          <div className="custom-block-${blockName}">
+            ${attributes
+              .map((attribute) => getGutenbergFieldBlock(attribute))
+              .join('\n\t\t\t\t\t')}
+          </div>
+        </div>
+      </Fragment>
+    );
+  }),
+
+  save() {
+    return null;
+    // or uncomment this if you import and use InnerBlocks from wordpress__block-editor
+    // return <InnerBlocks.Content />;
+  },
+});
+`;
+}
+
+function getGutenbergFieldBlock(attribute) {
+  switch (attribute.type) {
+    case 'string':
+      return `<RichText
+            identifier="${attribute.name}"
+            tagName="p"
+            value={attributes.${attribute.name}}
+            allowedFormats={[]}
+            // @ts-ignore
+            disableLineBreaks={true}
+            placeholder={__("${toTitleCase(attribute.name)}")}
+            keepPlaceholderOnFocus={true}
+            onChange={(newValue) => {
+              setAttributes({ ${attribute.name}: newValue })
+            }}
+          />`;
+    case 'array':
+      return ` <DrupalMediaEntity
+            className={'w-full'}
+            attributes={{
+              ...props.attributes,
+              lockViewMode: true,
+              allowedTypes: ['image'],
+            }}
+            setAttributes={props.setAttributes}
+            isMediaLibraryEnabled={true}
+            onError={(error) => {
+              // @ts-ignore
+              error = typeof error === 'string' ? error : error[2];
+              dispatch('core/notices').createWarningNotice(error);
+            }}
+            />`;
+  }
+}
+function toKebabCase(input) {
+  return input.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase();
+}
+function toTitleCase(input) {
+  return input
+    .split('-')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+function getFieldType(field) {
+  if (field.type.kind === 'NonNullType') {
+    return field.type.type.name?.value;
+  } else if (field.type.kind === 'NamedType') {
+    return field.type.name?.value;
+  } else {
+    // Handle other cases as needed
+    return null;
+  }
+}
+const [, , typeName] = process.argv;
+if (typeName) {
+  generateGutenbergBlockCode(typeName);
+} else {
+  console.error('Usage: node generate-gutenberg-block.js <GraphQLType>');
+}

--- a/packages/drupal/gutenberg_blocks/src/blocks/demo-block.tsx
+++ b/packages/drupal/gutenberg_blocks/src/blocks/demo-block.tsx
@@ -80,7 +80,7 @@ registerBlockType('custom/demo-block', {
             }}
           />
 					 <DrupalMediaEntity
-            className={'w-full'}
+            classname={'w-full'}
             attributes={{
               ...props.attributes,
               lockViewMode: true,

--- a/packages/drupal/gutenberg_blocks/src/blocks/demo-block.tsx
+++ b/packages/drupal/gutenberg_blocks/src/blocks/demo-block.tsx
@@ -1,0 +1,121 @@
+import React, { Fragment } from 'react';
+import {
+  InspectorControls,
+  RichText,
+} from 'wordpress__block-editor';
+import { registerBlockType } from 'wordpress__blocks';
+import { PanelBody } from 'wordpress__components';
+import { compose, withState } from 'wordpress__compose';
+import { dispatch } from 'wordpress__data';
+
+import { DrupalMediaEntity } from '../utils/drupal-media';
+
+// @ts-ignore
+const { t: __ } = Drupal;
+ // @ts-ignore
+registerBlockType('custom/demo-block', {
+  title: 'Demo Block',
+  icon: 'text',
+  category: 'common',
+  attributes: {
+    heading: {
+      type: 'string'
+    },
+		description: {
+      type: 'string'
+    },
+		mediaEntityIds: {
+      type: 'array'
+    },
+		url: {
+      type: 'string'
+    }
+  }, 
+  // @ts-ignore
+  edit: compose(withState())((props) => {
+    const { attributes, setAttributes } = props;
+    
+    // Set default values this way so that values get saved in the block's attributes.
+    //props.setAttributes({
+    //  isQuote:
+    //    props.attributes.isQuote === undefined
+    //      ? false
+    //      : props.attributes.isQuote,
+    //});
+    
+    return (
+      <Fragment>
+        <InspectorControls>
+          <PanelBody title={__('Block settings')}>  
+            <p>Block settings</p>
+          </PanelBody>
+        </InspectorControls>
+        <div className={'container-wrapper'}>
+          <div className={'container-label'}>{__('Demo Block')}</div>
+          <div className="custom-block-demo-block">
+            <RichText
+            identifier="heading"
+            tagName="p"
+            value={attributes.heading}
+            allowedFormats={[]}
+            // @ts-ignore
+            disableLineBreaks={true}
+            placeholder={__("Heading")}
+            keepPlaceholderOnFocus={true}
+            onChange={(newValue) => {
+              setAttributes({ heading: newValue })
+            }}
+          />
+					<RichText
+            identifier="description"
+            tagName="p"
+            value={attributes.description}
+            allowedFormats={[]}
+            // @ts-ignore
+            disableLineBreaks={true}
+            placeholder={__("Description")}
+            keepPlaceholderOnFocus={true}
+            onChange={(newValue) => {
+              setAttributes({ description: newValue })
+            }}
+          />
+					 <DrupalMediaEntity
+            className={'w-full'}
+            attributes={{
+              ...props.attributes,
+              lockViewMode: true,
+              allowedTypes: ['image'],
+            }}
+            setAttributes={props.setAttributes}
+            isMediaLibraryEnabled={true}
+            onError={(error) => {
+              // @ts-ignore
+              error = typeof error === 'string' ? error : error[2];
+              dispatch('core/notices').createWarningNotice(error);
+            }}
+            />
+					<RichText
+            identifier="url"
+            tagName="p"
+            value={attributes.url}
+            allowedFormats={[]}
+            // @ts-ignore
+            disableLineBreaks={true}
+            placeholder={__("Url")}
+            keepPlaceholderOnFocus={true}
+            onChange={(newValue) => {
+              setAttributes({ url: newValue })
+            }}
+          />
+          </div>
+        </div>
+      </Fragment>
+    );
+  }),
+
+  save() {
+    return null;
+    // or uncomment this if you import and use InnerBlocks from wordpress__block-editor
+    // return <InnerBlocks.Content />;
+  },
+});

--- a/packages/drupal/gutenberg_blocks/src/utils/drupal-media.tsx
+++ b/packages/drupal/gutenberg_blocks/src/utils/drupal-media.tsx
@@ -1,5 +1,5 @@
 type DrupalMediaComponent = React.FC<{
-  classname?: string;
+  className?: string;
   isMediaLibraryEnabled?: boolean;
   isSelected?: boolean;
   clientId?: string;

--- a/packages/drupal/gutenberg_blocks/src/utils/drupal-media.tsx
+++ b/packages/drupal/gutenberg_blocks/src/utils/drupal-media.tsx
@@ -1,5 +1,5 @@
 type DrupalMediaComponent = React.FC<{
-  className?: string;
+  classname?: string;
   isMediaLibraryEnabled?: boolean;
   isSelected?: boolean;
   clientId?: string;

--- a/packages/schema/src/schema.graphql
+++ b/packages/schema/src/schema.graphql
@@ -225,3 +225,10 @@ type MetaTagAttributes @default @value(json: "{}") {
   rel: String
   href: String
 }
+
+type DemoBlock {
+  heading: String!
+  description: Markup
+  image: MediaImage
+  url: Url!
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -280,9 +280,18 @@ importers:
 
   packages/drupal/gutenberg_blocks:
     dependencies:
+      '@types/node':
+        specifier: ^18
+        version: 18.19.4
       clsx:
         specifier: ^2.1.0
         version: 2.1.0
+      fs:
+        specifier: 0.0.1-security
+        version: 0.0.1-security
+      graphql:
+        specifier: 16.8.1
+        version: 16.8.1
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -7356,7 +7365,7 @@ packages:
       react-refresh: 0.14.0
       schema-utils: 3.3.0
       source-map: 0.7.4
-      webpack: 5.89.0(@swc/core@1.3.102)
+      webpack: 5.89.0(esbuild@0.19.11)
 
   /@pnpm/config.env-replace@1.1.0:
     resolution: {integrity: sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==}
@@ -12201,7 +12210,7 @@ packages:
       loader-utils: 2.0.4
       make-dir: 3.1.0
       schema-utils: 2.7.1
-      webpack: 5.89.0(@swc/core@1.3.102)
+      webpack: 5.89.0(esbuild@0.19.11)
 
   /babel-plugin-add-module-exports@1.0.4:
     resolution: {integrity: sha512-g+8yxHUZ60RcyaUpfNzy56OtWW+x9cyEe9j+CranqLiqbju2yf/Cy6ZtYK40EZxtrdHllzlVZgLmcOUCTlJ7Jg==}
@@ -12294,7 +12303,7 @@ packages:
       '@babel/core': 7.23.7
       '@babel/runtime': 7.23.7
       '@babel/types': 7.23.6
-      gatsby: 5.13.1(@swc/core@1.3.102)(babel-eslint@10.1.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
+      gatsby: 5.13.1(babel-eslint@10.1.0)(esbuild@0.19.11)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
       gatsby-core-utils: 4.13.0
 
   /babel-plugin-syntax-trailing-function-commas@7.0.0-beta.0:
@@ -14037,7 +14046,7 @@ packages:
       postcss-value-parser: 4.2.0
       schema-utils: 3.3.0
       semver: 7.5.4
-      webpack: 5.89.0(@swc/core@1.3.102)
+      webpack: 5.89.0(esbuild@0.19.11)
 
   /css-minimizer-webpack-plugin@2.0.0(webpack@5.89.0):
     resolution: {integrity: sha512-cG/uc94727tx5pBNtb1Sd7gvUPzwmcQi1lkpfqTpdkuNq75hJCw7bIVsCNijLm4dhDcr1atvuysl2rZqOG8Txw==}
@@ -14059,7 +14068,7 @@ packages:
       schema-utils: 3.3.0
       serialize-javascript: 5.0.1
       source-map: 0.6.1
-      webpack: 5.89.0(@swc/core@1.3.102)
+      webpack: 5.89.0(esbuild@0.19.11)
 
   /css-select@4.3.0:
     resolution: {integrity: sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==}
@@ -16644,7 +16653,7 @@ packages:
       micromatch: 4.0.5
       normalize-path: 3.0.0
       schema-utils: 3.3.0
-      webpack: 5.89.0(@swc/core@1.3.102)
+      webpack: 5.89.0(esbuild@0.19.11)
 
   /eslint@7.32.0:
     resolution: {integrity: sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==}
@@ -17317,7 +17326,7 @@ packages:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.89.0(@swc/core@1.3.102)
+      webpack: 5.89.0(esbuild@0.19.11)
 
   /file-system-cache@2.3.0:
     resolution: {integrity: sha512-l4DMNdsIPsVnKrgEXbJwDJsA5mB8rGwHYERMgqQx/xAUtChPJMre1bXBzDEqqVbWv9AIbFezXMxeEkZDSrXUOQ==}
@@ -17673,7 +17682,7 @@ packages:
       semver: 7.5.4
       tapable: 1.1.3
       typescript: 5.3.3
-      webpack: 5.89.0(@swc/core@1.3.102)
+      webpack: 5.89.0(esbuild@0.19.11)
 
   /form-data-encoder@2.1.4:
     resolution: {integrity: sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==}
@@ -17815,6 +17824,10 @@ packages:
   /fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  /fs@0.0.1-security:
+    resolution: {integrity: sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w==}
+    dev: false
+
   /fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -17940,7 +17953,7 @@ packages:
     dependencies:
       '@types/node-fetch': 2.6.10
       fs-extra: 9.1.0
-      gatsby: 5.13.1(@swc/core@1.3.102)(babel-eslint@10.1.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
+      gatsby: 5.13.1(babel-eslint@10.1.0)(esbuild@0.19.11)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
       lodash: 4.17.21
       node-fetch: 2.7.0
       p-queue: 6.6.2
@@ -18056,7 +18069,7 @@ packages:
       chokidar: 3.5.3
       fs-exists-cached: 1.0.0
       fs-extra: 11.2.0
-      gatsby: 5.13.1(@swc/core@1.3.102)(babel-eslint@10.1.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
+      gatsby: 5.13.1(babel-eslint@10.1.0)(esbuild@0.19.11)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
       gatsby-core-utils: 4.13.0
       gatsby-page-utils: 3.13.0
       gatsby-plugin-utils: 4.13.0(gatsby@5.13.1)(graphql@16.8.1)
@@ -18142,7 +18155,7 @@ packages:
       '@babel/preset-typescript': 7.23.3(@babel/core@7.23.7)
       '@babel/runtime': 7.23.7
       babel-plugin-remove-graphql-queries: 5.13.0(@babel/core@7.23.7)(gatsby@5.13.1)
-      gatsby: 5.13.1(@swc/core@1.3.102)(babel-eslint@10.1.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
+      gatsby: 5.13.1(babel-eslint@10.1.0)(esbuild@0.19.11)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -18160,7 +18173,7 @@ packages:
       '@babel/runtime': 7.23.7
       fastq: 1.16.0
       fs-extra: 11.2.0
-      gatsby: 5.13.1(@swc/core@1.3.102)(babel-eslint@10.1.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
+      gatsby: 5.13.1(babel-eslint@10.1.0)(esbuild@0.19.11)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
       gatsby-core-utils: 4.13.0
       gatsby-sharp: 1.13.0
       graphql: 16.8.1
@@ -18422,6 +18435,212 @@ packages:
       url-loader: 4.1.1(file-loader@6.2.0)(webpack@5.89.0)
       uuid: 8.3.2
       webpack: 5.89.0(@swc/core@1.3.102)
+      webpack-dev-middleware: 4.3.0(webpack@5.89.0)
+      webpack-merge: 5.10.0
+      webpack-stats-plugin: 1.1.3
+      webpack-virtual-modules: 0.5.0
+      xstate: 4.38.3
+      yaml-loader: 0.8.0
+    optionalDependencies:
+      gatsby-sharp: 1.13.0
+    transitivePeerDependencies:
+      - '@swc/core'
+      - '@types/webpack'
+      - babel-eslint
+      - bufferutil
+      - clean-css
+      - csso
+      - encoding
+      - esbuild
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - eslint-plugin-jest
+      - eslint-plugin-testing-library
+      - sockjs-client
+      - supports-color
+      - type-fest
+      - typescript
+      - uglify-js
+      - utf-8-validate
+      - vue-template-compiler
+      - webpack-cli
+      - webpack-dev-server
+      - webpack-hot-middleware
+      - webpack-plugin-serve
+    dev: true
+
+  /gatsby@5.13.1(babel-eslint@10.1.0)(esbuild@0.19.11)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3):
+    resolution: {integrity: sha512-y8VB381ZnHX3Xxc1n78AAAd+t0EsIyyIRtfqlSQ10CXwZHpZzBR3DTRoHmqIG3/NmdiqWhbHb/nRlmKZUzixtQ==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+    requiresBuild: true
+    peerDependencies:
+      react: ^18.0.0 || ^0.0.0
+      react-dom: ^18.0.0 || ^0.0.0
+    dependencies:
+      '@babel/code-frame': 7.23.5
+      '@babel/core': 7.23.7
+      '@babel/eslint-parser': 7.23.3(@babel/core@7.23.7)(eslint@7.32.0)
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/parser': 7.23.6
+      '@babel/runtime': 7.23.7
+      '@babel/traverse': 7.23.7
+      '@babel/types': 7.23.6
+      '@builder.io/partytown': 0.7.6
+      '@gatsbyjs/reach-router': 2.0.1(react-dom@18.2.0)(react@18.2.0)
+      '@gatsbyjs/webpack-hot-middleware': 2.25.3
+      '@graphql-codegen/add': 3.2.3(graphql@16.8.1)
+      '@graphql-codegen/core': 2.6.8(graphql@16.8.1)
+      '@graphql-codegen/plugin-helpers': 2.7.2(graphql@16.8.1)
+      '@graphql-codegen/typescript': 2.8.8(graphql@16.8.1)
+      '@graphql-codegen/typescript-operations': 2.5.13(graphql@16.8.1)
+      '@graphql-tools/code-file-loader': 7.3.23(@babel/core@7.23.7)(graphql@16.8.1)
+      '@graphql-tools/load': 7.8.14(graphql@16.8.1)
+      '@jridgewell/trace-mapping': 0.3.20
+      '@nodelib/fs.walk': 1.2.8
+      '@parcel/cache': 2.8.3(@parcel/core@2.8.3)
+      '@parcel/core': 2.8.3
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.11(react-refresh@0.14.0)(webpack@5.89.0)
+      '@types/http-proxy': 1.17.14
+      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0)(eslint@7.32.0)(typescript@5.3.3)
+      '@typescript-eslint/parser': 5.62.0(eslint@7.32.0)(typescript@5.3.3)
+      '@vercel/webpack-asset-relocator-loader': 1.7.3
+      acorn-loose: 8.4.0
+      acorn-walk: 8.3.1
+      address: 1.2.2
+      anser: 2.1.1
+      autoprefixer: 10.4.16(postcss@8.4.32)
+      axios: 0.21.4(debug@4.3.4)
+      babel-jsx-utils: 1.1.0
+      babel-loader: 8.3.0(@babel/core@7.23.7)(webpack@5.89.0)
+      babel-plugin-add-module-exports: 1.0.4
+      babel-plugin-dynamic-import-node: 2.3.3
+      babel-plugin-lodash: 3.3.4
+      babel-plugin-remove-graphql-queries: 5.13.0(@babel/core@7.23.7)(gatsby@5.13.1)
+      babel-preset-gatsby: 3.13.0(@babel/core@7.23.7)(core-js@3.35.0)
+      better-opn: 2.1.1
+      bluebird: 3.7.2
+      body-parser: 1.20.1
+      browserslist: 4.22.2
+      cache-manager: 2.11.1
+      chalk: 4.1.2
+      chokidar: 3.5.3
+      common-tags: 1.8.2
+      compression: 1.7.4
+      cookie: 0.5.0
+      core-js: 3.35.0
+      cors: 2.8.5
+      css-loader: 5.2.7(webpack@5.89.0)
+      css-minimizer-webpack-plugin: 2.0.0(webpack@5.89.0)
+      css.escape: 1.5.1
+      date-fns: 2.30.0
+      debug: 4.3.4
+      deepmerge: 4.3.1
+      detect-port: 1.5.1
+      devcert: 1.2.2
+      dotenv: 8.6.0
+      enhanced-resolve: 5.15.0
+      error-stack-parser: 2.1.4
+      eslint: 7.32.0
+      eslint-config-react-app: 6.0.0(@typescript-eslint/eslint-plugin@5.62.0)(@typescript-eslint/parser@5.62.0)(babel-eslint@10.1.0)(eslint-plugin-flowtype@5.10.0)(eslint-plugin-import@2.29.1)(eslint-plugin-jsx-a11y@6.8.0)(eslint-plugin-react-hooks@4.6.0)(eslint-plugin-react@7.33.2)(eslint@7.32.0)(typescript@5.3.3)
+      eslint-plugin-flowtype: 5.10.0(eslint@7.32.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0)(eslint@7.32.0)
+      eslint-plugin-jsx-a11y: 6.8.0(eslint@7.32.0)
+      eslint-plugin-react: 7.33.2(eslint@7.32.0)
+      eslint-plugin-react-hooks: 4.6.0(eslint@7.32.0)
+      eslint-webpack-plugin: 2.7.0(eslint@7.32.0)(webpack@5.89.0)
+      event-source-polyfill: 1.0.31
+      execa: 5.1.1
+      express: 4.18.2
+      express-http-proxy: 1.6.3
+      fastest-levenshtein: 1.0.16
+      fastq: 1.16.0
+      file-loader: 6.2.0(webpack@5.89.0)
+      find-cache-dir: 3.3.2
+      fs-exists-cached: 1.0.0
+      fs-extra: 11.2.0
+      gatsby-cli: 5.13.1
+      gatsby-core-utils: 4.13.0
+      gatsby-graphiql-explorer: 3.13.0
+      gatsby-legacy-polyfills: 3.13.0
+      gatsby-link: 5.13.0(@gatsbyjs/reach-router@2.0.1)(react-dom@18.2.0)(react@18.2.0)
+      gatsby-page-utils: 3.13.0
+      gatsby-parcel-config: 1.13.0(@parcel/core@2.8.3)
+      gatsby-plugin-page-creator: 5.13.0(gatsby@5.13.1)(graphql@16.8.1)
+      gatsby-plugin-typescript: 5.13.0(gatsby@5.13.1)
+      gatsby-plugin-utils: 4.13.0(gatsby@5.13.1)(graphql@16.8.1)
+      gatsby-react-router-scroll: 6.13.0(@gatsbyjs/reach-router@2.0.1)(react-dom@18.2.0)(react@18.2.0)
+      gatsby-script: 2.13.0(@gatsbyjs/reach-router@2.0.1)(react-dom@18.2.0)(react@18.2.0)
+      gatsby-telemetry: 4.13.0
+      gatsby-worker: 2.13.0
+      glob: 7.2.3
+      globby: 11.1.0
+      got: 11.8.6
+      graphql: 16.8.1
+      graphql-compose: 9.0.10(graphql@16.8.1)
+      graphql-http: 1.22.0(graphql@16.8.1)
+      graphql-tag: 2.12.6(graphql@16.8.1)
+      hasha: 5.2.2
+      invariant: 2.2.4
+      is-relative: 1.0.0
+      is-relative-url: 3.0.0
+      joi: 17.11.0
+      json-loader: 0.5.7
+      latest-version: 7.0.0
+      linkfs: 2.1.0
+      lmdb: 2.5.3
+      lodash: 4.17.21
+      meant: 1.0.3
+      memoizee: 0.4.15
+      micromatch: 4.0.5
+      mime: 3.0.0
+      mini-css-extract-plugin: 1.6.2(webpack@5.89.0)
+      mitt: 1.2.0
+      moment: 2.30.1
+      multer: 1.4.5-lts.1
+      node-fetch: 2.7.0
+      node-html-parser: 5.4.2
+      normalize-path: 3.0.0
+      null-loader: 4.0.1(webpack@5.89.0)
+      opentracing: 0.14.7
+      p-defer: 3.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 0.1.7
+      physical-cpu-count: 2.0.0
+      platform: 1.3.6
+      postcss: 8.4.32
+      postcss-flexbugs-fixes: 5.0.2(postcss@8.4.32)
+      postcss-loader: 5.3.0(postcss@8.4.32)(webpack@5.89.0)
+      prompts: 2.4.2
+      prop-types: 15.8.1
+      query-string: 6.14.1
+      raw-loader: 4.0.2(webpack@5.89.0)
+      react: 18.2.0
+      react-dev-utils: 12.0.1(eslint@7.32.0)(typescript@5.3.3)(webpack@5.89.0)
+      react-dom: 18.2.0(react@18.2.0)
+      react-refresh: 0.14.0
+      react-server-dom-webpack: 0.0.0-experimental-c8b778b7f-20220825(react@18.2.0)(webpack@5.89.0)
+      redux: 4.2.1
+      redux-thunk: 2.4.2(redux@4.2.1)
+      resolve-from: 5.0.0
+      semver: 7.5.4
+      shallow-compare: 1.2.2
+      signal-exit: 3.0.7
+      slugify: 1.6.6
+      socket.io: 4.7.1
+      socket.io-client: 4.7.1
+      stack-trace: 0.0.10
+      string-similarity: 1.2.2
+      strip-ansi: 6.0.1
+      style-loader: 2.0.0(webpack@5.89.0)
+      style-to-object: 0.4.4
+      terser-webpack-plugin: 5.3.10(esbuild@0.19.11)(webpack@5.89.0)
+      tmp: 0.2.1
+      true-case-path: 2.2.1
+      type-of: 2.0.1
+      url-loader: 4.1.1(file-loader@6.2.0)(webpack@5.89.0)
+      uuid: 8.3.2
+      webpack: 5.89.0(esbuild@0.19.11)
       webpack-dev-middleware: 4.3.0(webpack@5.89.0)
       webpack-merge: 5.10.0
       webpack-stats-plugin: 1.1.3
@@ -23232,7 +23451,7 @@ packages:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.89.0(@swc/core@1.3.102)
+      webpack: 5.89.0(esbuild@0.19.11)
       webpack-sources: 1.4.3
 
   /mini-svg-data-uri@1.4.4:
@@ -24065,7 +24284,7 @@ packages:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.89.0(@swc/core@1.3.102)
+      webpack: 5.89.0(esbuild@0.19.11)
 
   /nullthrows@1.1.1:
     resolution: {integrity: sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==}
@@ -25275,7 +25494,7 @@ packages:
       klona: 2.0.6
       postcss: 8.4.32
       semver: 7.5.4
-      webpack: 5.89.0(@swc/core@1.3.102)
+      webpack: 5.89.0(esbuild@0.19.11)
 
   /postcss-merge-longhand@5.1.7(postcss@8.4.32):
     resolution: {integrity: sha512-YCI9gZB+PLNskrK0BB3/2OzPnGhPkBEwmwhfYk1ilBHYVAZB7/tkTHFBAnCrvBBOmeYyMYw3DMjT55SyxMBzjQ==}
@@ -26242,7 +26461,7 @@ packages:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.89.0(@swc/core@1.3.102)
+      webpack: 5.89.0(esbuild@0.19.11)
 
   /rbush@3.0.1:
     resolution: {integrity: sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==}
@@ -26416,7 +26635,7 @@ packages:
       strip-ansi: 6.0.1
       text-table: 0.2.0
       typescript: 5.3.3
-      webpack: 5.89.0(@swc/core@1.3.102)
+      webpack: 5.89.0(esbuild@0.19.11)
     transitivePeerDependencies:
       - eslint
       - supports-color
@@ -26822,7 +27041,7 @@ packages:
       loose-envify: 1.4.0
       neo-async: 2.6.2
       react: 18.2.0
-      webpack: 5.89.0(@swc/core@1.3.102)
+      webpack: 5.89.0(esbuild@0.19.11)
 
   /react-split-pane@0.1.92(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-GfXP1xSzLMcLJI5BM36Vh7GgZBpy+U/X0no+VM3fxayv+p1Jly5HpMofZJraeaMl73b3hvlr+N9zJKvLB/uz9w==}
@@ -29177,7 +29396,7 @@ packages:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.89.0(@swc/core@1.3.102)
+      webpack: 5.89.0(esbuild@0.19.11)
 
   /style-to-object@0.3.0:
     resolution: {integrity: sha512-CzFnRRXhzWIdItT3OmF8SQfWyahHhjq3HwcMNCNLn+N7klOOqPjMeG/4JSu77D7ypZdGvSzvkrbyeTMizz2VrA==}
@@ -29511,6 +29730,31 @@ packages:
       serialize-javascript: 6.0.1
       terser: 5.26.0
       webpack: 5.89.0(@swc/core@1.3.102)
+    dev: true
+
+  /terser-webpack-plugin@5.3.10(esbuild@0.19.11)(webpack@5.89.0):
+    resolution: {integrity: sha512-BKFPWlPDndPs+NGGCr1U59t0XScL5317Y0UReNrHaw9/FwhPENlq6bfgs+4yPfyP51vqC1bQ4rp1EfXW5ZSH9w==}
+    engines: {node: '>= 10.13.0'}
+    peerDependencies:
+      '@swc/core': '*'
+      esbuild: '*'
+      uglify-js: '*'
+      webpack: ^5.1.0
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      esbuild:
+        optional: true
+      uglify-js:
+        optional: true
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.20
+      esbuild: 0.19.11
+      jest-worker: 27.5.1
+      schema-utils: 3.3.0
+      serialize-javascript: 6.0.1
+      terser: 5.26.0
+      webpack: 5.89.0(esbuild@0.19.11)
 
   /terser-webpack-plugin@5.3.10(webpack@5.89.0):
     resolution: {integrity: sha512-BKFPWlPDndPs+NGGCr1U59t0XScL5317Y0UReNrHaw9/FwhPENlq6bfgs+4yPfyP51vqC1bQ4rp1EfXW5ZSH9w==}
@@ -30702,7 +30946,7 @@ packages:
       loader-utils: 2.0.4
       mime-types: 2.1.35
       schema-utils: 3.3.0
-      webpack: 5.89.0(@swc/core@1.3.102)
+      webpack: 5.89.0(esbuild@0.19.11)
 
   /url@0.11.3:
     resolution: {integrity: sha512-6hxOLGfZASQK/cijlZnZJTq8OXAkt/3YGfQX45vvMYXpZoo8NdWZcY73K108Jf759lS1Bv/8wXnHDTSz17dSRw==}
@@ -31546,7 +31790,7 @@ packages:
       mime-types: 2.1.35
       range-parser: 1.2.1
       schema-utils: 3.3.0
-      webpack: 5.89.0(@swc/core@1.3.102)
+      webpack: 5.89.0(esbuild@0.19.11)
 
   /webpack-merge@5.10.0:
     resolution: {integrity: sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==}
@@ -31648,6 +31892,46 @@ packages:
       schema-utils: 3.3.0
       tapable: 2.2.1
       terser-webpack-plugin: 5.3.10(@swc/core@1.3.102)(webpack@5.89.0)
+      watchpack: 2.4.0
+      webpack-sources: 3.2.3
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
+    dev: true
+
+  /webpack@5.89.0(esbuild@0.19.11):
+    resolution: {integrity: sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+    peerDependencies:
+      webpack-cli: '*'
+    peerDependenciesMeta:
+      webpack-cli:
+        optional: true
+    dependencies:
+      '@types/eslint-scope': 3.7.7
+      '@types/estree': 1.0.5
+      '@webassemblyjs/ast': 1.11.6
+      '@webassemblyjs/wasm-edit': 1.11.6
+      '@webassemblyjs/wasm-parser': 1.11.6
+      acorn: 8.11.3
+      acorn-import-assertions: 1.9.0(acorn@8.11.3)
+      browserslist: 4.22.2
+      chrome-trace-event: 1.0.3
+      enhanced-resolve: 5.15.0
+      es-module-lexer: 1.4.1
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.3.0
+      mime-types: 2.1.35
+      neo-async: 2.6.2
+      schema-utils: 3.3.0
+      tapable: 2.2.1
+      terser-webpack-plugin: 5.3.10(esbuild@0.19.11)(webpack@5.89.0)
       watchpack: 2.4.0
       webpack-sources: 3.2.3
     transitivePeerDependencies:


### PR DESCRIPTION
## Description of changes

Add a script and package.json command to easily generated Gutenberg block files based off a schema type. Currently has basica support but really does speed up my day-to-day workflow.

## Motivation and context

Speed up development time by automating repetitive tasks. Developers manually add to index.ts in gutenberg_blocks but this could also be automated.

## How has this been tested?

Locally. Example output can be seen in demo-block.tsx