### PR TITLE
PHPStorm tuning

### DIFF
--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -7,13 +7,28 @@
     <option name="transferred" value="true" />
   </component>
   <component name="PHPCodeSnifferOptionsConfiguration">
+    <option name="codingStandard" value="Drupal" />
+    <option name="extensions" value="php,js,css,inc,module,install,profile" />
     <option name="highlightLevel" value="WARNING" />
+    <option name="installedPaths" value="$PROJECT_DIR$/apps/cms/vendor/drupal/coder/coder_sniffer" />
+    <option name="showSniffs" value="true" />
     <option name="transferred" value="true" />
+  </component>
+  <component name="PhpCodeSniffer">
+    <phpcs_settings>
+      <PhpCSConfiguration beautifier_path="$PROJECT_DIR$/apps/cms/vendor/bin/phpcbf" standards="Drupal;DrupalPractice;MySource;PEAR;PSR1;PSR12;PSR2;SlevomatCodingStandard;Squiz;VariableAnalysis;Zend" tool_path="$PROJECT_DIR$/apps/cms/vendor/bin/phpcs" />
+    </phpcs_settings>
   </component>
   <component name="PhpProjectSharedConfiguration" php_language_level="8.1">
     <option name="suggestChangeDefaultLanguageLevel" value="false" />
   </component>
+  <component name="PhpStan">
+    <PhpStan_settings>
+      <PhpStanConfiguration tool_path="$PROJECT_DIR$/apps/cms/vendor/bin/phpstan" />
+    </PhpStan_settings>
+  </component>
   <component name="PhpStanOptionsConfiguration">
+    <option name="level" value="8" />
     <option name="transferred" value="true" />
   </component>
   <component name="PhpUnit">

--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -19,7 +19,15 @@
       <PhpCSConfiguration beautifier_path="$PROJECT_DIR$/apps/cms/vendor/bin/phpcbf" standards="Drupal;DrupalPractice;MySource;PEAR;PSR1;PSR12;PSR2;SlevomatCodingStandard;Squiz;VariableAnalysis;Zend" tool_path="$PROJECT_DIR$/apps/cms/vendor/bin/phpcs" />
     </phpcs_settings>
   </component>
-  <component name="PhpProjectSharedConfiguration" php_language_level="8.1">
+  <component name="PhpIncludePathManager">
+    <include_path>
+      <path value="$PROJECT_DIR$/packages/drupal" />
+      <path value="$PROJECT_DIR$/apps/cms/web/modules/contrib" />
+      <path value="$PROJECT_DIR$/apps/cms/vendor" />
+      <path value="$PROJECT_DIR$/apps/cms/web/core" />
+    </include_path>
+  </component>
+  <component name="PhpProjectSharedConfiguration" php_language_level="8.2">
     <option name="suggestChangeDefaultLanguageLevel" value="false" />
   </component>
   <component name="PhpStan">

--- a/.idea/silverback-template.iml
+++ b/.idea/silverback-template.iml
@@ -2,27 +2,24 @@
 <module type="WEB_MODULE" version="4">
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$">
-      <sourceFolder url="file://$MODULE_DIR$/apps/cms/web/core" isTestSource="false" packagePrefix="Drupal" />
-      <sourceFolder url="file://$MODULE_DIR$/apps/cms/web/core/lib" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/apps/cms/web/core/tests" isTestSource="true" />
-      <excludeFolder url="file://$MODULE_DIR$/apps/cms/web/modules/custom" />
-      <excludeFolder url="file://$MODULE_DIR$/apps/cms/generated/graphql" />
-      <excludeFolder url="file://$MODULE_DIR$/apps/website/.cache" />
-      <excludeFolder url="file://$MODULE_DIR$/apps/website/public" />
-      <excludeFolder url="file://$MODULE_DIR$/packages/schema/build" />
-      <excludeFolder url="file://$MODULE_DIR$/packages/ui/build" />
       <excludeFolder url="file://$MODULE_DIR$/_local" />
-      <excludeFolder url="file://$MODULE_DIR$/apps/cms/.turbo" />
-      <excludeFolder url="file://$MODULE_DIR$/apps/website/.turbo" />
-      <excludeFolder url="file://$MODULE_DIR$/packages/drupal/gutenberg_blocks/.turbo" />
-      <excludeFolder url="file://$MODULE_DIR$/packages/schema/.turbo" />
-      <excludeFolder url="file://$MODULE_DIR$/packages/ui/.turbo" />
+      <excludeFolder url="file://$MODULE_DIR$/apps/website/public" />
       <excludeFolder url="file://$MODULE_DIR$/packages/ui/coverage" />
       <excludeFolder url="file://$MODULE_DIR$/packages/ui/storybook-static" />
       <excludeFolder url="file://$MODULE_DIR$/tests/e2e/.auth" />
-      <excludeFolder url="file://$MODULE_DIR$/tests/e2e/.turbo" />
       <excludeFolder url="file://$MODULE_DIR$/tests/e2e/playwright-report" />
-      <excludeFolder url="file://$MODULE_DIR$/tests/schema/.turbo" />
+      <excludeFolder url="file://$MODULE_DIR$/packages/schema/src/generated" />
+      <excludeFolder url="file://$MODULE_DIR$/apps/cms/vendor" />
+      <excludeFolder url="file://$MODULE_DIR$/apps/cms/web/core" />
+      <excludeFolder url="file://$MODULE_DIR$/apps/cms/web/libraries" />
+      <excludeFolder url="file://$MODULE_DIR$/apps/cms/web/modules/contrib" />
+      <excludeFolder url="file://$MODULE_DIR$/apps/cms/web/sites" />
+      <excludeFolder url="file://$MODULE_DIR$/apps/cms/web/themes/contrib" />
+      <excludePattern pattern=".turbo" />
+      <excludePattern pattern="build" />
+      <excludePattern pattern="dist" />
+      <excludePattern pattern=".cache" />
+      <excludePattern pattern=".vite" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/.idea/symfony2.xml
+++ b/.idea/symfony2.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Symfony2PluginSettings">
+    <option name="pluginEnabled" value="true" />
+  </component>
+</project>

--- a/.idea/watcherTasks.xml
+++ b/.idea/watcherTasks.xml
@@ -2,7 +2,7 @@
 <project version="4">
   <component name="ProjectTasksOptions">
     <TaskOptions isEnabled="true">
-      <option name="arguments" value="turbo prep" />
+      <option name="arguments" value="run watcher" />
       <option name="checkSyntaxErrors" value="true" />
       <option name="description" />
       <option name="exitCodeBehavior" value="ERROR" />
@@ -15,7 +15,7 @@
       </option>
       <option name="outputFromStdout" value="false" />
       <option name="program" value="pnpm" />
-      <option name="runOnExternalChanges" value="true" />
+      <option name="runOnExternalChanges" value="false" />
       <option name="scopeName" value="GraphQL Schema Inputs" />
       <option name="trackOnlyRoot" value="false" />
       <option name="workingDir" value="$PROJECT_DIR$/packages/schema" />

--- a/packages/schema/.gitignore
+++ b/packages/schema/.gitignore
@@ -1,2 +1,3 @@
 src/generated
+src/directives.graphql
 build

--- a/packages/schema/.graphqlrc.json
+++ b/packages/schema/.graphqlrc.json
@@ -1,10 +1,5 @@
 {
   "$schema": "https://unpkg.com/graphql-config@5.0.3/config-schema.json",
-  "schema": [
-    "node_modules/@amazeelabs/*/directives.graphql",
-    "../../apps/cms/web/modules/contrib/*/directives.graphql",
-    "../../apps/cms/web/modules/custom/*/directives.graphql",
-    "src/schema.graphql"
-  ],
+  "schema": ["src/directives.graphql", "src/schema.graphql"],
   "documents": ["src/**/*.gql"]
 }

--- a/packages/schema/codegen.directives.ts
+++ b/packages/schema/codegen.directives.ts
@@ -1,0 +1,18 @@
+import type { CodegenConfig } from '@graphql-codegen/cli';
+
+const config: CodegenConfig = {
+  schema: [
+    'node_modules/@amazeelabs/*/directives.graphql',
+    '../../apps/cms/web/modules/contrib/*/directives.graphql',
+  ],
+  generates: {
+    'src/directives.graphql': {
+      plugins: ['schema-ast'],
+      config: {
+        includeDirectives: true,
+      },
+    },
+  },
+};
+
+export default config;

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -38,7 +38,8 @@
     "watch:codegen": "graphql-codegen --verbose --watch",
     "watch:swc": "swc ./src -d ./build --watch",
     "watch:tsc": "tsc --emitDeclarationOnly --watch",
-    "prep:codegen": "graphql-codegen --verbose",
+    "prep:directives": "graphql-codegen -c codegen.directives.ts --verbose",
+    "prep:codegen": "graphql-codegen",
     "prep:scripts": "swc ./src -d ./build",
     "prep:types": "tsc --emitDeclarationOnly"
   },

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -41,7 +41,8 @@
     "prep:directives": "graphql-codegen -c codegen.directives.ts --verbose",
     "prep:codegen": "graphql-codegen",
     "prep:scripts": "swc ./src -d ./build",
-    "prep:types": "tsc --emitDeclarationOnly"
+    "prep:types": "tsc --emitDeclarationOnly",
+    "watcher": "graphql-codegen && tsc --emitDeclarationOnly"
   },
   "devDependencies": {
     "@amazeelabs/codegen-autoloader": "^1.1.3",

--- a/packages/schema/src/schema.graphql
+++ b/packages/schema/src/schema.graphql
@@ -27,12 +27,12 @@ For Drupal, this is implicitly implemented in the "graphql_directives" module.
 implementation(gatsby): ./page.js#loadEntity
 """
 directive @loadEntity(
+  id: String
+  operation: String
   route: String
   type: String
   uuid: String
-  id: String
-  operation: String
-) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+) repeatable on ENUM | FIELD_DEFINITION | INTERFACE | OBJECT | SCALAR | UNION
 
 """
 Parse a given Url.

--- a/packages/schema/turbo.json
+++ b/packages/schema/turbo.json
@@ -2,8 +2,13 @@
   "$schema": "https://turborepo.org/schema.json",
   "extends": ["//"],
   "pipeline": {
-    "prep:codegen": {
+    "prep:directives": {
       "dependsOn": ["@custom/cms#prep:composer"],
+      "inputs": ["package.json"],
+      "outputs": ["src/directives.graphql"]
+    },
+    "prep:codegen": {
+      "dependsOn": ["prep:directives"],
       "inputs": [
         "codegen.ts",
         ".graphqlrc.json",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,3 +2,5 @@ parameters:
   ignoreErrors:
     # new static() is a best practice in Drupal, so we cannot fix that.
     - "#^Unsafe usage of new static#"
+  drupal:
+    drupal_root: apps/cms


### PR DESCRIPTION
## Description of changes

- Tune excluded directories
- Configure linting and formatting for PHP
- Aggregate graphql directives in a single file that all IDE's can pick up
- Faster graphql file watcher (for small tasks turbo has A LOT of overhead)

## Motivation and context

More reliable and faster PHPStorm setup.
