### PR TITLE
fix(SLB-269): special handling for home page translations

### DIFF
--- a/packages/schema/src/operations/Frame.gql
+++ b/packages/schema/src/operations/Frame.gql
@@ -1,4 +1,12 @@
 query Frame {
+  websiteSettings {
+    homePage {
+      translations {
+        locale
+        path
+      }
+    }
+  }
   mainNavigation: mainNavigations {
     ...Navigation
   }

--- a/packages/ui/src/components/Molecules/LanguageSwitcher.stories.tsx
+++ b/packages/ui/src/components/Molecules/LanguageSwitcher.stories.tsx
@@ -1,15 +1,29 @@
-import { Url } from '@custom/schema';
+import { FrameQuery, registerExecutor, Url } from '@custom/schema';
 import { Decorator, Meta, StoryObj } from '@storybook/react';
 import React from 'react';
 
 import { Translations, TranslationsProvider } from '../../utils/translations';
+import { Default } from '../Routes/Frame.stories';
 import { LanguageSwitcher } from './LanguageSwitcher';
 
-const TranslationsDecorator = ((Story, ctx) => (
-  <TranslationsProvider defaultTranslations={ctx.args}>
-    <Story />
-  </TranslationsProvider>
-)) as Decorator<Translations>;
+const TranslationsDecorator = ((Story, ctx) => {
+  registerExecutor(FrameQuery, {
+    ...Default.args,
+    websiteSettings: {
+      homePage: {
+        translations: [
+          { locale: 'en', path: '/en/home' as Url },
+          { locale: 'de', path: '/de/home' as Url },
+        ],
+      },
+    },
+  });
+  return (
+    <TranslationsProvider defaultTranslations={ctx.args}>
+      <Story />
+    </TranslationsProvider>
+  );
+}) as Decorator<Translations>;
 
 export default {
   component: LanguageSwitcher,
@@ -33,5 +47,15 @@ export const Full = {
   args: {
     de: '/de/german-version' as Url,
     en: '/en/english-version' as Url,
+  },
+} satisfies Story;
+
+export const Homepage = {
+  args: {
+    de: '/de/home' as Url,
+    en: '/en/home' as Url,
+  },
+  parameters: {
+    location: new URL('local:/de'),
   },
 } satisfies Story;

--- a/packages/ui/src/components/Routes/Page.stories.tsx
+++ b/packages/ui/src/components/Routes/Page.stories.tsx
@@ -1,4 +1,10 @@
-import { Locale, registerExecutor, Url, ViewPageQuery } from '@custom/schema';
+import {
+  FrameQuery,
+  Locale,
+  registerExecutor,
+  Url,
+  ViewPageQuery,
+} from '@custom/schema';
 import Landscape from '@stories/landscape.jpg?as=metadata';
 import { Meta, StoryObj } from '@storybook/react';
 import React from 'react';
@@ -6,6 +12,7 @@ import React from 'react';
 import { image } from '../../helpers/image';
 import { Mixed, Paragraph } from '../Organisms/PageContent/BlockMarkup.stories';
 import { WithCaption } from '../Organisms/PageContent/BlockMedia.stories';
+import { Default as FrameStory } from './Frame.stories';
 import { Page } from './Page';
 
 export default {
@@ -15,6 +22,7 @@ export default {
 export const Default = {
   render: (args) => {
     registerExecutor(ViewPageQuery, () => args);
+    registerExecutor(FrameQuery, FrameStory.args);
     return <Page />;
   },
   args: {


### PR DESCRIPTION
## Description of changes

Add a special handling for the language switcher on home pages.

## Motivation and context

Indication of the current translations was not correct for home pages.

## How has this been tested?

- [x] Manually
- [x] Unit tests
- [x] Integration tests
