### PR TITLE
refactor: upgrade to @amazeelabs/executors 2.0

### DIFF
--- a/apps/decap/src/helpers/frame.tsx
+++ b/apps/decap/src/helpers/frame.tsx
@@ -1,4 +1,4 @@
-import { FrameQuery, Locale, registerExecutor, Url } from '@custom/schema';
+import { FrameQuery, Locale, OperationExecutor, Url } from '@custom/schema';
 import { NavigationItemSource } from '@custom/schema/source';
 import { Frame } from '@custom/ui/routes/Frame';
 import { PropsWithChildren } from 'react';
@@ -15,20 +15,26 @@ const menuItems = (amount: number) =>
   );
 
 export function PreviewFrame({ children }: PropsWithChildren) {
-  registerExecutor(FrameQuery, () => ({
-    mainNavigation: [
-      {
-        locale: Locale.En,
-        items: menuItems(4),
-      },
-    ],
-    footerNavigation: [
-      {
-        locale: Locale.En,
-        items: menuItems(4),
-      },
-    ],
-    stringTranslations: [],
-  }));
-  return <Frame>{children}</Frame>;
+  return (
+    <OperationExecutor
+      id={FrameQuery}
+      executor={{
+        mainNavigation: [
+          {
+            locale: Locale.En,
+            items: menuItems(4),
+          },
+        ],
+        footerNavigation: [
+          {
+            locale: Locale.En,
+            items: menuItems(4),
+          },
+        ],
+        stringTranslations: [],
+      }}
+    >
+      <Frame>{children}</Frame>
+    </OperationExecutor>
+  );
 }

--- a/apps/decap/src/main.tsx
+++ b/apps/decap/src/main.tsx
@@ -1,8 +1,8 @@
 import { TokenAuthBackend } from '@amazeelabs/decap-cms-backend-token-auth/backend';
 import {
   Locale,
+  OperationExecutor,
   PreviewDecapPageQuery,
-  registerExecutor,
   ViewPageQuery,
 } from '@custom/schema';
 import { Page } from '@custom/ui/routes/Page';
@@ -81,8 +81,11 @@ CMS.registerPreviewTemplate(
     PreviewDecapPageQuery,
     pageSchema,
     (data) => {
-      registerExecutor(ViewPageQuery, { page: data.preview });
-      return <Page />;
+      return (
+        <OperationExecutor executor={{ page: data.preview }} id={ViewPageQuery}>
+          <Page />
+        </OperationExecutor>
+      );
     },
     'previewDecapPage',
   ),

--- a/apps/website/gatsby-browser.ts
+++ b/apps/website/gatsby-browser.ts
@@ -1,13 +1,6 @@
 import '@custom/ui/styles.css';
 
-import { registerExecutor } from '@custom/schema';
 import { GatsbyBrowser } from 'gatsby';
-
-import { drupalExecutor } from './src/utils/drupal-executor';
-
-export const onClientEntry: GatsbyBrowser['onClientEntry'] = async () => {
-  registerExecutor(drupalExecutor(`/graphql`));
-};
 
 export const shouldUpdateScroll: GatsbyBrowser['shouldUpdateScroll'] = (
   args,

--- a/apps/website/gatsby-ssr.ts
+++ b/apps/website/gatsby-ssr.ts
@@ -1,13 +1,10 @@
-import { Locale, registerExecutor } from '@custom/schema';
+import { Locale } from '@custom/schema';
 import { GatsbySSR } from 'gatsby';
-
-import { drupalExecutor } from './src/utils/drupal-executor';
 
 export const onRenderBody: GatsbySSR['onRenderBody'] = ({
   setHtmlAttributes,
   pathname,
 }) => {
-  registerExecutor(drupalExecutor(`/graphql`));
   const locales = Object.values(Locale);
   if (locales.length === 1) {
     // Single-language project.

--- a/apps/website/src/layouts/index.tsx
+++ b/apps/website/src/layouts/index.tsx
@@ -1,7 +1,9 @@
 import { graphql, useStaticQuery } from '@amazeelabs/gatsby-plugin-operations';
-import { FrameQuery, registerExecutor } from '@custom/schema';
+import { FrameQuery, OperationExecutor } from '@custom/schema';
 import { Frame } from '@custom/ui/routes/Frame';
 import React, { PropsWithChildren } from 'react';
+
+import { drupalExecutor } from '../utils/drupal-executor';
 
 export default function Layout({
   children,
@@ -9,6 +11,11 @@ export default function Layout({
   locale: string;
 }>) {
   const data = useStaticQuery(graphql(FrameQuery));
-  registerExecutor(FrameQuery, data);
-  return <Frame>{children}</Frame>;
+  return (
+    <OperationExecutor executor={drupalExecutor(`/graphql`)}>
+      <OperationExecutor executor={data} id={FrameQuery}>
+        <Frame>{children}</Frame>
+      </OperationExecutor>
+    </OperationExecutor>
+  );
 }

--- a/apps/website/src/pages/404.tsx
+++ b/apps/website/src/pages/404.tsx
@@ -1,5 +1,5 @@
 import { graphql } from '@amazeelabs/gatsby-plugin-operations';
-import { NotFoundPageQuery, registerExecutor } from '@custom/schema';
+import { NotFoundPageQuery, OperationExecutor } from '@custom/schema';
 import { NotFoundPage } from '@custom/ui/routes/NotFoundPage';
 import { PageProps } from 'gatsby';
 import React from 'react';
@@ -7,6 +7,9 @@ import React from 'react';
 export const query = graphql(NotFoundPageQuery);
 
 export default function Index({ data }: PageProps<typeof query>) {
-  registerExecutor(NotFoundPageQuery, {}, data);
-  return <NotFoundPage />;
+  return (
+    <OperationExecutor executor={data} id={NotFoundPageQuery}>
+      <NotFoundPage />
+    </OperationExecutor>
+  );
 }

--- a/apps/website/src/preview/page.tsx
+++ b/apps/website/src/preview/page.tsx
@@ -1,6 +1,6 @@
 import {
+  OperationExecutor,
   PreviewDrupalPageQuery,
-  registerExecutor,
   ViewPageQuery,
 } from '@custom/schema';
 import { Page } from '@custom/ui/routes/Page';
@@ -17,15 +17,21 @@ const previewExecutor = drupalExecutor(
 export default function PagePreview() {
   const { nid, rid, lang } = usePreviewParameters();
   if (nid && rid && lang) {
-    registerExecutor(ViewPageQuery, async () => {
-      const data = await previewExecutor(PreviewDrupalPageQuery, {
-        id: nid,
-        locale: lang,
-        rid,
-      });
-      return { page: data.preview };
-    });
-    return <Page />;
+    return (
+      <OperationExecutor
+        id={ViewPageQuery}
+        executor={async () => {
+          const data = await previewExecutor(PreviewDrupalPageQuery, {
+            id: nid,
+            locale: lang,
+            rid,
+          });
+          return { page: data.preview };
+        }}
+      >
+        <Page />
+      </OperationExecutor>
+    );
   }
   return null;
 }

--- a/apps/website/src/templates/home.tsx
+++ b/apps/website/src/templates/home.tsx
@@ -1,5 +1,5 @@
 import { graphql } from '@amazeelabs/gatsby-plugin-operations';
-import { HomePageQuery, registerExecutor, useLocalized } from '@custom/schema';
+import { HomePageQuery, OperationExecutor, useLocalized } from '@custom/schema';
 import { HomePage } from '@custom/ui/routes/HomePage';
 import { HeadProps, PageProps } from 'gatsby';
 import React from 'react';
@@ -36,6 +36,9 @@ export function Head({ data }: HeadProps<typeof query>) {
 }
 
 export default function Index({ data }: PageProps<typeof query>) {
-  registerExecutor(HomePageQuery, {}, data);
-  return <HomePage />;
+  return (
+    <OperationExecutor executor={data} id={HomePageQuery}>
+      <HomePage />
+    </OperationExecutor>
+  );
 }

--- a/apps/website/src/templates/page.tsx
+++ b/apps/website/src/templates/page.tsx
@@ -1,5 +1,5 @@
 import { graphql } from '@amazeelabs/gatsby-plugin-operations';
-import { registerExecutor, useLocation, ViewPageQuery } from '@custom/schema';
+import { OperationExecutor, useLocation, ViewPageQuery } from '@custom/schema';
 import { Page } from '@custom/ui/routes/Page';
 import { HeadProps, PageProps } from 'gatsby';
 import React from 'react';
@@ -41,6 +41,13 @@ export default function PageTemplate({ data }: PageProps<typeof query>) {
   // That makes shure the `useOperation(ViewPageQuery, ...)` with this
   // path immediately returns this data.
   const [location] = useLocation();
-  registerExecutor(ViewPageQuery, { pathname: location.pathname }, data);
-  return <Page />;
+  return (
+    <OperationExecutor
+      id={ViewPageQuery}
+      executor={data}
+      variables={{ pathname: location.pathname }}
+    >
+      <Page />
+    </OperationExecutor>
+  );
 }

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -51,6 +51,7 @@
     "@graphql-codegen/schema-ast": "^4.0.0",
     "@graphql-codegen/typescript": "^4.0.1",
     "@graphql-codegen/typescript-operations": "^4.0.1",
+    "@types/react": "^18.2.46",
     "@swc/cli": "^0.1.62",
     "@swc/core": "^1.3.67",
     "@types/image-size": "^0.8.0",
@@ -61,7 +62,7 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@amazeelabs/executors": "^1.1.0",
+    "@amazeelabs/executors": "^2.0.0",
     "@amazeelabs/gatsby-silverback-cloudinary": "^1.2.7",
     "@amazeelabs/gatsby-source-silverback": "^1.13.10",
     "@amazeelabs/scalars": "^1.6.13",

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -1,15 +1,14 @@
 import {
-  createExecutor as untypedCreateExecutor,
-  registerExecutor as untypedRegisterExecutor,
+  OperationExecutor as UntypedOperationExecutor,
+  useExecutor as untypedUseExecutor,
 } from '@amazeelabs/executors';
+import { PropsWithChildren } from 'react';
 
 import type {
   AnyOperationId,
   OperationResult,
   OperationVariables,
 } from './generated/index.js';
-
-export { clearRegistry } from '@amazeelabs/executors';
 
 export * from './generated/index.js';
 export * from '@amazeelabs/scalars';
@@ -27,30 +26,21 @@ type VariablesMatcher<OperationId extends AnyOperationId> =
   | Partial<OperationVariables<OperationId>>
   | ((vars: OperationVariables<OperationId>) => boolean);
 
-export function registerExecutor<OperationId extends AnyOperationId>(
-  executor: Executor<OperationId>,
-): void;
-
-export function registerExecutor<OperationId extends AnyOperationId>(
-  id: OperationId,
-  executor: Executor<OperationId>,
-): void;
-
-export function registerExecutor<OperationId extends AnyOperationId>(
-  id: OperationId,
-  variables: VariablesMatcher<OperationVariables<OperationId>>,
-  executor: Executor<OperationId>,
-): void;
-
-export function registerExecutor(...args: [unknown]) {
-  return untypedRegisterExecutor(...args);
+export function OperationExecutor<OperationId extends AnyOperationId>(
+  props: PropsWithChildren<{
+    id?: OperationId;
+    variables?: VariablesMatcher<OperationVariables<OperationId>>;
+    executor: Executor<OperationId>;
+  }>,
+) {
+  return UntypedOperationExecutor(props);
 }
 
-export function createExecutor<OperationId extends AnyOperationId>(
+export function useExecutor<OperationId extends AnyOperationId>(
   id: OperationId,
   variables?: OperationVariables<OperationId>,
 ):
   | OperationResult<OperationId>
   | (() => Promise<OperationResult<OperationId>>) {
-  return untypedCreateExecutor(id, variables);
+  return untypedUseExecutor(id, variables);
 }

--- a/packages/ui/.storybook/preview.tsx
+++ b/packages/ui/.storybook/preview.tsx
@@ -1,6 +1,6 @@
 import '../src/tailwind.css';
 
-import { clearRegistry, LocationProvider } from '@custom/schema';
+import { LocationProvider } from '@custom/schema';
 import { Decorator } from '@storybook/react';
 import React from 'react';
 import { IntlProvider } from 'react-intl';
@@ -12,11 +12,6 @@ const IntlDecorator: Decorator = (Story) => (
     <Story />
   </IntlProvider>
 );
-
-const OperatorDecorator: Decorator = (Story) => {
-  clearRegistry();
-  return <Story />;
-};
 
 const LocationDecorator: Decorator = (Story, ctx) => {
   return (
@@ -66,9 +61,4 @@ export const parameters = {
   chromatic: { viewports: [320, 840, 1440] },
 };
 
-export const decorators = [
-  LocationDecorator,
-  IntlDecorator,
-  OperatorDecorator,
-  SWRCacheDecorator,
-];
+export const decorators = [LocationDecorator, IntlDecorator, SWRCacheDecorator];

--- a/packages/ui/src/components/Molecules/LanguageSwitcher.stories.tsx
+++ b/packages/ui/src/components/Molecules/LanguageSwitcher.stories.tsx
@@ -1,4 +1,4 @@
-import { FrameQuery, registerExecutor, Url } from '@custom/schema';
+import { FrameQuery, OperationExecutor, Url } from '@custom/schema';
 import { Decorator, Meta, StoryObj } from '@storybook/react';
 import React from 'react';
 
@@ -7,21 +7,25 @@ import { Default } from '../Routes/Frame.stories';
 import { LanguageSwitcher } from './LanguageSwitcher';
 
 const TranslationsDecorator = ((Story, ctx) => {
-  registerExecutor(FrameQuery, {
-    ...Default.args,
-    websiteSettings: {
-      homePage: {
-        translations: [
-          { locale: 'en', path: '/en/home' as Url },
-          { locale: 'de', path: '/de/home' as Url },
-        ],
-      },
-    },
-  });
   return (
-    <TranslationsProvider defaultTranslations={ctx.args}>
-      <Story />
-    </TranslationsProvider>
+    <OperationExecutor
+      id={FrameQuery}
+      executor={{
+        ...Default.args,
+        websiteSettings: {
+          homePage: {
+            translations: [
+              { locale: 'en', path: '/en/home' as Url },
+              { locale: 'de', path: '/de/home' as Url },
+            ],
+          },
+        },
+      }}
+    >
+      <TranslationsProvider defaultTranslations={ctx.args}>
+        <Story />
+      </TranslationsProvider>
+    </OperationExecutor>
   );
 }) as Decorator<Translations>;
 

--- a/packages/ui/src/components/Organisms/ContentHub.stories.tsx
+++ b/packages/ui/src/components/Organisms/ContentHub.stories.tsx
@@ -1,9 +1,9 @@
 import {
   ContentHubQuery,
   ContentHubResultItemFragment,
+  OperationExecutor,
   OperationResult,
   OperationVariables,
-  registerExecutor,
   Url,
 } from '@custom/schema';
 import Landscape from '@stories/landscape.jpg?as=metadata';
@@ -22,8 +22,11 @@ type ContentHubExecutor = (
 export default {
   title: 'Components/Organisms/ContentHub',
   render: (args) => {
-    registerExecutor(ContentHubQuery, args.exec);
-    return <ContentHub pageSize={6} />;
+    return (
+      <OperationExecutor executor={args.exec} id={ContentHubQuery}>
+        <ContentHub pageSize={6} />
+      </OperationExecutor>
+    );
   },
 } satisfies Meta<{ exec: ContentHubExecutor }>;
 

--- a/packages/ui/src/components/Organisms/Footer.stories.tsx
+++ b/packages/ui/src/components/Organisms/Footer.stories.tsx
@@ -1,4 +1,4 @@
-import { FrameQuery, Locale, registerExecutor, Url } from '@custom/schema';
+import { FrameQuery, Locale, OperationExecutor, Url } from '@custom/schema';
 import { Meta, StoryObj } from '@storybook/react';
 import React from 'react';
 
@@ -13,8 +13,11 @@ export default {
 
 export const Footer = {
   render: (args) => {
-    registerExecutor(FrameQuery, () => args);
-    return <Component />;
+    return (
+      <OperationExecutor id={FrameQuery} executor={() => args}>
+        <Component />
+      </OperationExecutor>
+    );
   },
   args: {
     footerNavigation: [

--- a/packages/ui/src/components/Organisms/Header.stories.tsx
+++ b/packages/ui/src/components/Organisms/Header.stories.tsx
@@ -1,4 +1,4 @@
-import { FrameQuery, Locale, registerExecutor, Url } from '@custom/schema';
+import { FrameQuery, Locale, OperationExecutor, Url } from '@custom/schema';
 import { Meta, StoryObj } from '@storybook/react';
 import { userEvent, within } from '@storybook/test';
 import React from 'react';
@@ -15,8 +15,11 @@ export default {
 
 export const Idle = {
   render: (args) => {
-    registerExecutor(FrameQuery, () => args);
-    return <Header />;
+    return (
+      <OperationExecutor id={FrameQuery} executor={() => args}>
+        <Header />
+      </OperationExecutor>
+    );
   },
   args: {
     mainNavigation: [

--- a/packages/ui/src/components/Routes/Frame.stories.tsx
+++ b/packages/ui/src/components/Routes/Frame.stories.tsx
@@ -1,4 +1,4 @@
-import { FrameQuery, registerExecutor } from '@custom/schema';
+import { FrameQuery, OperationExecutor } from '@custom/schema';
 import { Meta, StoryObj } from '@storybook/react';
 import React from 'react';
 
@@ -15,8 +15,11 @@ export default {
 
 export const Default = {
   render: (args) => {
-    registerExecutor(FrameQuery, () => args);
-    return <Frame />;
+    return (
+      <OperationExecutor executor={() => args} id={FrameQuery}>
+        <Frame />
+      </OperationExecutor>
+    );
   },
   args: {
     mainNavigation: HeaderStory.args.mainNavigation,

--- a/packages/ui/src/components/Routes/Page.stories.tsx
+++ b/packages/ui/src/components/Routes/Page.stories.tsx
@@ -1,7 +1,7 @@
 import {
   FrameQuery,
   Locale,
-  registerExecutor,
+  OperationExecutor,
   Url,
   ViewPageQuery,
 } from '@custom/schema';
@@ -21,9 +21,13 @@ export default {
 
 export const Default = {
   render: (args) => {
-    registerExecutor(ViewPageQuery, () => args);
-    registerExecutor(FrameQuery, FrameStory.args);
-    return <Page />;
+    return (
+      <OperationExecutor executor={() => args} id={ViewPageQuery}>
+        <OperationExecutor executor={FrameStory.args} id={FrameQuery}>
+          <Page />
+        </OperationExecutor>
+      </OperationExecutor>
+    );
   },
   args: {
     page: {

--- a/packages/ui/src/pages.stories.tsx
+++ b/packages/ui/src/pages.stories.tsx
@@ -1,7 +1,7 @@
 import {
   ContentHubQuery,
   FrameQuery,
-  registerExecutor,
+  OperationExecutor,
   ViewPageQuery,
 } from '@custom/schema';
 import { Meta, StoryFn } from '@storybook/react';
@@ -25,21 +25,25 @@ export default {
 } satisfies Meta;
 
 export const ContentPage = (() => {
-  registerExecutor(FrameQuery, () => FrameStory.args);
-  registerExecutor(ViewPageQuery, () => PageStory.args);
   return (
-    <Frame>
-      <Page />
-    </Frame>
+    <OperationExecutor executor={PageStory.args} id={ViewPageQuery}>
+      <OperationExecutor executor={FrameStory.args} id={FrameQuery}>
+        <Frame>
+          <Page />
+        </Frame>
+      </OperationExecutor>
+    </OperationExecutor>
   );
 }) satisfies StoryFn;
 
 export const ContentHubPage = (() => {
-  registerExecutor(FrameQuery, () => FrameStory.args);
-  registerExecutor(ContentHubQuery, WithResults.args.exec);
   return (
-    <Frame>
-      <ContentHub pageSize={6} />
-    </Frame>
+    <OperationExecutor executor={FrameStory.args} id={FrameQuery}>
+      <OperationExecutor executor={WithResults.args.exec} id={ContentHubQuery}>
+        <Frame>
+          <ContentHub pageSize={6} />
+        </Frame>
+      </OperationExecutor>
+    </OperationExecutor>
   );
 }) satisfies StoryFn;

--- a/packages/ui/src/utils/operation.ts
+++ b/packages/ui/src/utils/operation.ts
@@ -1,8 +1,8 @@
 import {
   AnyOperationId,
-  createExecutor,
   OperationResult,
   OperationVariables,
+  useExecutor,
 } from '@custom/schema';
 import useSwr, { SWRResponse } from 'swr';
 
@@ -10,7 +10,7 @@ export function useOperation<TOperation extends AnyOperationId>(
   operation: TOperation,
   variables?: OperationVariables<TOperation>,
 ): Omit<SWRResponse<OperationResult<TOperation>>, 'mutate'> {
-  const executor = createExecutor(operation, variables);
+  const executor = useExecutor(operation, variables);
   // If the executor is a function, use SWR to manage it.
   const result = useSwr<OperationResult<TOperation>>(
     [operation, variables],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -359,8 +359,8 @@ importers:
   packages/schema:
     dependencies:
       '@amazeelabs/executors':
-        specifier: ^1.1.0
-        version: 1.1.0
+        specifier: ^2.0.0
+        version: 2.0.0(react-dom@18.2.0)(react@18.2.0)
       '@amazeelabs/gatsby-silverback-cloudinary':
         specifier: ^1.2.7
         version: 1.2.7
@@ -407,6 +407,9 @@ importers:
       '@types/node':
         specifier: ^18
         version: 18.19.4
+      '@types/react':
+        specifier: ^18.2.46
+        version: 18.2.46
       concurrently:
         specifier: ^8.2.2
         version: 8.2.2
@@ -819,10 +822,15 @@ packages:
     dev: false
     optional: true
 
-  /@amazeelabs/executors@1.1.0:
-    resolution: {integrity: sha512-W7Q1JV0zyraAcHdv3cUDFNNonflq/WuTtqtS0zT1VrZAyInNDPT5nSgTiJ4V9RqD+3lVhBk6jMlSsQkCPa3B8A==}
+  /@amazeelabs/executors@2.0.0(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-MESvU/bJuxe9CfRWP9wkXpgxmxrdao9Pm6X7kaqbLoxDl+0kSOVkC6Z6PuhUD338QeKnBEaavYpV81mYGk24uA==}
+    peerDependencies:
+      react: ^18
+      react-dom: ^18
     dependencies:
       lodash-es: 4.17.21
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
   /@amazeelabs/gatsby-plugin-operations@1.1.3:
@@ -6552,7 +6560,7 @@ packages:
       react-refresh: 0.14.0
       schema-utils: 3.3.0
       source-map: 0.7.4
-      webpack: 5.89.0(esbuild@0.19.11)
+      webpack: 5.89.0
 
   /@pnpm/config.env-replace@1.1.0:
     resolution: {integrity: sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==}
@@ -9339,7 +9347,6 @@ packages:
       typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0)(eslint@7.32.0)(typescript@5.3.3):
     resolution: {integrity: sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==}
@@ -9367,6 +9374,7 @@ packages:
       typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0)(eslint@7.32.0)(typescript@5.4.2):
     resolution: {integrity: sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==}
@@ -9444,7 +9452,6 @@ packages:
       typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.3.3):
     resolution: {integrity: sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==}
@@ -9521,7 +9528,6 @@ packages:
       typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@typescript-eslint/type-utils@5.62.0(eslint@7.32.0)(typescript@5.3.3):
     resolution: {integrity: sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==}
@@ -9542,6 +9548,7 @@ packages:
       typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@typescript-eslint/type-utils@5.62.0(eslint@7.32.0)(typescript@5.4.2):
     resolution: {integrity: sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==}
@@ -9635,7 +9642,6 @@ packages:
       typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@typescript-eslint/typescript-estree@5.62.0(typescript@5.3.3):
     resolution: {integrity: sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==}
@@ -9741,7 +9747,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - typescript
-    dev: false
 
   /@typescript-eslint/utils@5.62.0(eslint@7.32.0)(typescript@5.3.3):
     resolution: {integrity: sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==}
@@ -9762,6 +9767,7 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - typescript
+    dev: true
 
   /@typescript-eslint/utils@5.62.0(eslint@7.32.0)(typescript@5.4.2):
     resolution: {integrity: sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==}
@@ -11606,7 +11612,7 @@ packages:
       loader-utils: 2.0.4
       make-dir: 3.1.0
       schema-utils: 2.7.1
-      webpack: 5.89.0(esbuild@0.19.11)
+      webpack: 5.89.0
 
   /babel-plugin-add-module-exports@1.0.4:
     resolution: {integrity: sha512-g+8yxHUZ60RcyaUpfNzy56OtWW+x9cyEe9j+CranqLiqbju2yf/Cy6ZtYK40EZxtrdHllzlVZgLmcOUCTlJ7Jg==}
@@ -11699,7 +11705,7 @@ packages:
       '@babel/core': 7.23.7
       '@babel/runtime': 7.23.7
       '@babel/types': 7.23.6
-      gatsby: 5.13.1(babel-eslint@10.1.0)(esbuild@0.19.11)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
+      gatsby: 5.13.1(babel-eslint@10.1.0)(react-dom@18.2.0)(react@18.2.0)(typescript@4.9.5)
       gatsby-core-utils: 4.13.0
 
   /babel-plugin-syntax-trailing-function-commas@7.0.0-beta.0:
@@ -13466,7 +13472,7 @@ packages:
       postcss-value-parser: 4.2.0
       schema-utils: 3.3.0
       semver: 7.5.4
-      webpack: 5.89.0(esbuild@0.19.11)
+      webpack: 5.89.0
 
   /css-minimizer-webpack-plugin@2.0.0(webpack@5.89.0):
     resolution: {integrity: sha512-cG/uc94727tx5pBNtb1Sd7gvUPzwmcQi1lkpfqTpdkuNq75hJCw7bIVsCNijLm4dhDcr1atvuysl2rZqOG8Txw==}
@@ -13488,7 +13494,7 @@ packages:
       schema-utils: 3.3.0
       serialize-javascript: 5.0.1
       source-map: 0.6.1
-      webpack: 5.89.0(esbuild@0.19.11)
+      webpack: 5.89.0
 
   /css-select@4.3.0:
     resolution: {integrity: sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==}
@@ -15657,7 +15663,6 @@ packages:
       eslint-plugin-react: 7.33.2(eslint@7.32.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@7.32.0)
       typescript: 4.9.5
-    dev: false
 
   /eslint-config-react-app@6.0.0(@typescript-eslint/eslint-plugin@5.62.0)(@typescript-eslint/parser@5.62.0)(babel-eslint@10.1.0)(eslint-plugin-flowtype@5.10.0)(eslint-plugin-import@2.29.1)(eslint-plugin-jsx-a11y@6.8.0)(eslint-plugin-react-hooks@4.6.0)(eslint-plugin-react@7.33.2)(eslint@7.32.0)(typescript@5.3.3):
     resolution: {integrity: sha512-bpoAAC+YRfzq0dsTk+6v9aHm/uqnDwayNAXleMypGl6CpxI9oXXscVHo4fk3eJPIn+rsbtNetB4r/ZIidFIE8A==}
@@ -15694,6 +15699,7 @@ packages:
       eslint-plugin-react: 7.33.2(eslint@7.32.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@7.32.0)
       typescript: 5.3.3
+    dev: true
 
   /eslint-import-resolver-node@0.3.9:
     resolution: {integrity: sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==}
@@ -15725,7 +15731,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.62.0(eslint@7.32.0)(typescript@5.3.3)
+      '@typescript-eslint/parser': 5.62.0(eslint@7.32.0)(typescript@4.9.5)
       debug: 3.2.7
       eslint: 7.32.0
       eslint-import-resolver-node: 0.3.9
@@ -15803,7 +15809,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.62.0(eslint@7.32.0)(typescript@5.3.3)
+      '@typescript-eslint/parser': 5.62.0(eslint@7.32.0)(typescript@4.9.5)
       array-includes: 3.1.7
       array.prototype.findlastindex: 1.2.3
       array.prototype.flat: 1.3.2
@@ -16009,7 +16015,7 @@ packages:
       micromatch: 4.0.5
       normalize-path: 3.0.0
       schema-utils: 3.3.0
-      webpack: 5.89.0(esbuild@0.19.11)
+      webpack: 5.89.0
 
   /eslint@7.32.0:
     resolution: {integrity: sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==}
@@ -16721,7 +16727,7 @@ packages:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.89.0(esbuild@0.19.11)
+      webpack: 5.89.0
 
   /file-system-cache@2.3.0:
     resolution: {integrity: sha512-l4DMNdsIPsVnKrgEXbJwDJsA5mB8rGwHYERMgqQx/xAUtChPJMre1bXBzDEqqVbWv9AIbFezXMxeEkZDSrXUOQ==}
@@ -17044,7 +17050,6 @@ packages:
       tapable: 1.1.3
       typescript: 4.9.5
       webpack: 5.89.0
-    dev: false
 
   /fork-ts-checker-webpack-plugin@6.5.3(eslint@7.32.0)(typescript@5.3.3)(webpack@5.89.0):
     resolution: {integrity: sha512-SbH/l9ikmMWycd5puHJKTkZJKddF4iRLyW3DeZ08HTI7NGyLS38MXd/KGgeWumQO7YNQbW2u/NtPT2YowbPaGQ==}
@@ -17076,6 +17081,7 @@ packages:
       tapable: 1.1.3
       typescript: 5.3.3
       webpack: 5.89.0(esbuild@0.19.11)
+    dev: true
 
   /form-data-encoder@2.1.4:
     resolution: {integrity: sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==}
@@ -17340,7 +17346,7 @@ packages:
     dependencies:
       '@types/node-fetch': 2.6.10
       fs-extra: 9.1.0
-      gatsby: 5.13.1(babel-eslint@10.1.0)(esbuild@0.19.11)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
+      gatsby: 5.13.1(babel-eslint@10.1.0)(react-dom@18.2.0)(react@18.2.0)(typescript@4.9.5)
       lodash: 4.17.21
       node-fetch: 2.7.0
       p-queue: 6.6.2
@@ -17456,7 +17462,7 @@ packages:
       chokidar: 3.5.3
       fs-exists-cached: 1.0.0
       fs-extra: 11.2.0
-      gatsby: 5.13.1(babel-eslint@10.1.0)(esbuild@0.19.11)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
+      gatsby: 5.13.1(babel-eslint@10.1.0)(react-dom@18.2.0)(react@18.2.0)(typescript@4.9.5)
       gatsby-core-utils: 4.13.0
       gatsby-page-utils: 3.13.0
       gatsby-plugin-utils: 4.13.0(gatsby@5.13.1)(graphql@16.8.1)
@@ -17542,7 +17548,7 @@ packages:
       '@babel/preset-typescript': 7.23.3(@babel/core@7.23.7)
       '@babel/runtime': 7.23.7
       babel-plugin-remove-graphql-queries: 5.13.0(@babel/core@7.23.7)(gatsby@5.13.1)
-      gatsby: 5.13.1(babel-eslint@10.1.0)(esbuild@0.19.11)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
+      gatsby: 5.13.1(babel-eslint@10.1.0)(react-dom@18.2.0)(react@18.2.0)(typescript@4.9.5)
     transitivePeerDependencies:
       - supports-color
 
@@ -17560,7 +17566,7 @@ packages:
       '@babel/runtime': 7.23.7
       fastq: 1.16.0
       fs-extra: 11.2.0
-      gatsby: 5.13.1(babel-eslint@10.1.0)(esbuild@0.19.11)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
+      gatsby: 5.13.1(babel-eslint@10.1.0)(react-dom@18.2.0)(react@18.2.0)(typescript@4.9.5)
       gatsby-core-utils: 4.13.0
       gatsby-sharp: 1.13.0
       graphql: 16.8.1
@@ -17856,211 +17862,6 @@ packages:
       - webpack-plugin-serve
     dev: true
 
-  /gatsby@5.13.1(babel-eslint@10.1.0)(esbuild@0.19.11)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3):
-    resolution: {integrity: sha512-y8VB381ZnHX3Xxc1n78AAAd+t0EsIyyIRtfqlSQ10CXwZHpZzBR3DTRoHmqIG3/NmdiqWhbHb/nRlmKZUzixtQ==}
-    engines: {node: '>=18.0.0'}
-    hasBin: true
-    requiresBuild: true
-    peerDependencies:
-      react: ^18.0.0 || ^0.0.0
-      react-dom: ^18.0.0 || ^0.0.0
-    dependencies:
-      '@babel/code-frame': 7.23.5
-      '@babel/core': 7.23.7
-      '@babel/eslint-parser': 7.23.3(@babel/core@7.23.7)(eslint@7.32.0)
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/parser': 7.23.6
-      '@babel/runtime': 7.23.7
-      '@babel/traverse': 7.23.7
-      '@babel/types': 7.23.6
-      '@builder.io/partytown': 0.7.6
-      '@gatsbyjs/reach-router': 2.0.1(react-dom@18.2.0)(react@18.2.0)
-      '@gatsbyjs/webpack-hot-middleware': 2.25.3
-      '@graphql-codegen/add': 3.2.3(graphql@16.8.1)
-      '@graphql-codegen/core': 2.6.8(graphql@16.8.1)
-      '@graphql-codegen/plugin-helpers': 2.7.2(graphql@16.8.1)
-      '@graphql-codegen/typescript': 2.8.8(graphql@16.8.1)
-      '@graphql-codegen/typescript-operations': 2.5.13(graphql@16.8.1)
-      '@graphql-tools/code-file-loader': 7.3.23(@babel/core@7.23.7)(graphql@16.8.1)
-      '@graphql-tools/load': 7.8.14(graphql@16.8.1)
-      '@jridgewell/trace-mapping': 0.3.20
-      '@nodelib/fs.walk': 1.2.8
-      '@parcel/cache': 2.8.3(@parcel/core@2.8.3)
-      '@parcel/core': 2.8.3
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.11(react-refresh@0.14.0)(webpack@5.89.0)
-      '@types/http-proxy': 1.17.14
-      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0)(eslint@7.32.0)(typescript@5.3.3)
-      '@typescript-eslint/parser': 5.62.0(eslint@7.32.0)(typescript@5.3.3)
-      '@vercel/webpack-asset-relocator-loader': 1.7.3
-      acorn-loose: 8.4.0
-      acorn-walk: 8.3.1
-      address: 1.2.2
-      anser: 2.1.1
-      autoprefixer: 10.4.16(postcss@8.4.32)
-      axios: 0.21.4(debug@4.3.4)
-      babel-jsx-utils: 1.1.0
-      babel-loader: 8.3.0(@babel/core@7.23.7)(webpack@5.89.0)
-      babel-plugin-add-module-exports: 1.0.4
-      babel-plugin-dynamic-import-node: 2.3.3
-      babel-plugin-lodash: 3.3.4
-      babel-plugin-remove-graphql-queries: 5.13.0(@babel/core@7.23.7)(gatsby@5.13.1)
-      babel-preset-gatsby: 3.13.0(@babel/core@7.23.7)(core-js@3.35.0)
-      better-opn: 2.1.1
-      bluebird: 3.7.2
-      body-parser: 1.20.1
-      browserslist: 4.22.2
-      cache-manager: 2.11.1
-      chalk: 4.1.2
-      chokidar: 3.5.3
-      common-tags: 1.8.2
-      compression: 1.7.4
-      cookie: 0.5.0
-      core-js: 3.35.0
-      cors: 2.8.5
-      css-loader: 5.2.7(webpack@5.89.0)
-      css-minimizer-webpack-plugin: 2.0.0(webpack@5.89.0)
-      css.escape: 1.5.1
-      date-fns: 2.30.0
-      debug: 4.3.4
-      deepmerge: 4.3.1
-      detect-port: 1.5.1
-      devcert: 1.2.2
-      dotenv: 8.6.0
-      enhanced-resolve: 5.15.0
-      error-stack-parser: 2.1.4
-      eslint: 7.32.0
-      eslint-config-react-app: 6.0.0(@typescript-eslint/eslint-plugin@5.62.0)(@typescript-eslint/parser@5.62.0)(babel-eslint@10.1.0)(eslint-plugin-flowtype@5.10.0)(eslint-plugin-import@2.29.1)(eslint-plugin-jsx-a11y@6.8.0)(eslint-plugin-react-hooks@4.6.0)(eslint-plugin-react@7.33.2)(eslint@7.32.0)(typescript@5.3.3)
-      eslint-plugin-flowtype: 5.10.0(eslint@7.32.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0)(eslint@7.32.0)
-      eslint-plugin-jsx-a11y: 6.8.0(eslint@7.32.0)
-      eslint-plugin-react: 7.33.2(eslint@7.32.0)
-      eslint-plugin-react-hooks: 4.6.0(eslint@7.32.0)
-      eslint-webpack-plugin: 2.7.0(eslint@7.32.0)(webpack@5.89.0)
-      event-source-polyfill: 1.0.31
-      execa: 5.1.1
-      express: 4.18.2
-      express-http-proxy: 1.6.3
-      fastest-levenshtein: 1.0.16
-      fastq: 1.16.0
-      file-loader: 6.2.0(webpack@5.89.0)
-      find-cache-dir: 3.3.2
-      fs-exists-cached: 1.0.0
-      fs-extra: 11.2.0
-      gatsby-cli: 5.13.1
-      gatsby-core-utils: 4.13.0
-      gatsby-graphiql-explorer: 3.13.0
-      gatsby-legacy-polyfills: 3.13.0
-      gatsby-link: 5.13.0(@gatsbyjs/reach-router@2.0.1)(react-dom@18.2.0)(react@18.2.0)
-      gatsby-page-utils: 3.13.0
-      gatsby-parcel-config: 1.13.0(@parcel/core@2.8.3)
-      gatsby-plugin-page-creator: 5.13.0(gatsby@5.13.1)(graphql@16.8.1)
-      gatsby-plugin-typescript: 5.13.0(gatsby@5.13.1)
-      gatsby-plugin-utils: 4.13.0(gatsby@5.13.1)(graphql@16.8.1)
-      gatsby-react-router-scroll: 6.13.0(@gatsbyjs/reach-router@2.0.1)(react-dom@18.2.0)(react@18.2.0)
-      gatsby-script: 2.13.0(@gatsbyjs/reach-router@2.0.1)(react-dom@18.2.0)(react@18.2.0)
-      gatsby-telemetry: 4.13.0
-      gatsby-worker: 2.13.0
-      glob: 7.2.3
-      globby: 11.1.0
-      got: 11.8.6
-      graphql: 16.8.1
-      graphql-compose: 9.0.10(graphql@16.8.1)
-      graphql-http: 1.22.0(graphql@16.8.1)
-      graphql-tag: 2.12.6(graphql@16.8.1)
-      hasha: 5.2.2
-      invariant: 2.2.4
-      is-relative: 1.0.0
-      is-relative-url: 3.0.0
-      joi: 17.11.0
-      json-loader: 0.5.7
-      latest-version: 7.0.0
-      linkfs: 2.1.0
-      lmdb: 2.5.3
-      lodash: 4.17.21
-      meant: 1.0.3
-      memoizee: 0.4.15
-      micromatch: 4.0.5
-      mime: 3.0.0
-      mini-css-extract-plugin: 1.6.2(webpack@5.89.0)
-      mitt: 1.2.0
-      moment: 2.30.1
-      multer: 1.4.5-lts.1
-      node-fetch: 2.7.0
-      node-html-parser: 5.4.2
-      normalize-path: 3.0.0
-      null-loader: 4.0.1(webpack@5.89.0)
-      opentracing: 0.14.7
-      p-defer: 3.0.0
-      parseurl: 1.3.3
-      path-to-regexp: 0.1.7
-      physical-cpu-count: 2.0.0
-      platform: 1.3.6
-      postcss: 8.4.32
-      postcss-flexbugs-fixes: 5.0.2(postcss@8.4.32)
-      postcss-loader: 5.3.0(postcss@8.4.32)(webpack@5.89.0)
-      prompts: 2.4.2
-      prop-types: 15.8.1
-      query-string: 6.14.1
-      raw-loader: 4.0.2(webpack@5.89.0)
-      react: 18.2.0
-      react-dev-utils: 12.0.1(eslint@7.32.0)(typescript@5.3.3)(webpack@5.89.0)
-      react-dom: 18.2.0(react@18.2.0)
-      react-refresh: 0.14.0
-      react-server-dom-webpack: 0.0.0-experimental-c8b778b7f-20220825(react@18.2.0)(webpack@5.89.0)
-      redux: 4.2.1
-      redux-thunk: 2.4.2(redux@4.2.1)
-      resolve-from: 5.0.0
-      semver: 7.5.4
-      shallow-compare: 1.2.2
-      signal-exit: 3.0.7
-      slugify: 1.6.6
-      socket.io: 4.7.1
-      socket.io-client: 4.7.1
-      stack-trace: 0.0.10
-      string-similarity: 1.2.2
-      strip-ansi: 6.0.1
-      style-loader: 2.0.0(webpack@5.89.0)
-      style-to-object: 0.4.4
-      terser-webpack-plugin: 5.3.10(esbuild@0.19.11)(webpack@5.89.0)
-      tmp: 0.2.1
-      true-case-path: 2.2.1
-      type-of: 2.0.1
-      url-loader: 4.1.1(file-loader@6.2.0)(webpack@5.89.0)
-      uuid: 8.3.2
-      webpack: 5.89.0(esbuild@0.19.11)
-      webpack-dev-middleware: 4.3.0(webpack@5.89.0)
-      webpack-merge: 5.10.0
-      webpack-stats-plugin: 1.1.3
-      webpack-virtual-modules: 0.5.0
-      xstate: 4.38.3
-      yaml-loader: 0.8.0
-    optionalDependencies:
-      gatsby-sharp: 1.13.0
-    transitivePeerDependencies:
-      - '@swc/core'
-      - '@types/webpack'
-      - babel-eslint
-      - bufferutil
-      - clean-css
-      - csso
-      - encoding
-      - esbuild
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - eslint-plugin-jest
-      - eslint-plugin-testing-library
-      - sockjs-client
-      - supports-color
-      - type-fest
-      - typescript
-      - uglify-js
-      - utf-8-validate
-      - vue-template-compiler
-      - webpack-cli
-      - webpack-dev-server
-      - webpack-hot-middleware
-      - webpack-plugin-serve
-
   /gatsby@5.13.1(babel-eslint@10.1.0)(react-dom@18.2.0)(react@18.2.0)(typescript@4.9.5):
     resolution: {integrity: sha512-y8VB381ZnHX3Xxc1n78AAAd+t0EsIyyIRtfqlSQ10CXwZHpZzBR3DTRoHmqIG3/NmdiqWhbHb/nRlmKZUzixtQ==}
     engines: {node: '>=18.0.0'}
@@ -18265,7 +18066,6 @@ packages:
       - webpack-dev-server
       - webpack-hot-middleware
       - webpack-plugin-serve
-    dev: false
 
   /gauge@3.0.2:
     resolution: {integrity: sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==}
@@ -22863,7 +22663,7 @@ packages:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.89.0(esbuild@0.19.11)
+      webpack: 5.89.0
       webpack-sources: 1.4.3
 
   /mini-svg-data-uri@1.4.4:
@@ -23694,7 +23494,7 @@ packages:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.89.0(esbuild@0.19.11)
+      webpack: 5.89.0
 
   /nullthrows@1.1.1:
     resolution: {integrity: sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==}
@@ -24899,7 +24699,7 @@ packages:
       klona: 2.0.6
       postcss: 8.4.32
       semver: 7.5.4
-      webpack: 5.89.0(esbuild@0.19.11)
+      webpack: 5.89.0
 
   /postcss-merge-longhand@5.1.7(postcss@8.4.32):
     resolution: {integrity: sha512-YCI9gZB+PLNskrK0BB3/2OzPnGhPkBEwmwhfYk1ilBHYVAZB7/tkTHFBAnCrvBBOmeYyMYw3DMjT55SyxMBzjQ==}
@@ -25842,7 +25642,7 @@ packages:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.89.0(esbuild@0.19.11)
+      webpack: 5.89.0
 
   /rbush@3.0.1:
     resolution: {integrity: sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==}
@@ -25978,7 +25778,6 @@ packages:
       - eslint
       - supports-color
       - vue-template-compiler
-    dev: false
 
   /react-dev-utils@12.0.1(eslint@7.32.0)(typescript@5.3.3)(webpack@5.89.0):
     resolution: {integrity: sha512-84Ivxmr17KjUupyqzFode6xKhjwuEJDROWKJy/BthkL7Wn6NJ8h4WE6k/exAv6ImS+0oZLRRW5j/aINMHyeGeQ==}
@@ -26020,6 +25819,7 @@ packages:
       - eslint
       - supports-color
       - vue-template-compiler
+    dev: true
 
   /react-dnd-html5-backend@14.1.0:
     resolution: {integrity: sha512-6ONeqEC3XKVf4eVmMTe0oPds+c5B9Foyj8p/ZKLb7kL2qh9COYxiBHv3szd6gztqi/efkmriywLUVlPotqoJyw==}
@@ -26421,7 +26221,7 @@ packages:
       loose-envify: 1.4.0
       neo-async: 2.6.2
       react: 18.2.0
-      webpack: 5.89.0(esbuild@0.19.11)
+      webpack: 5.89.0
 
   /react-split-pane@0.1.92(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-GfXP1xSzLMcLJI5BM36Vh7GgZBpy+U/X0no+VM3fxayv+p1Jly5HpMofZJraeaMl73b3hvlr+N9zJKvLB/uz9w==}
@@ -28754,7 +28554,7 @@ packages:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.89.0(esbuild@0.19.11)
+      webpack: 5.89.0
 
   /style-to-object@0.3.0:
     resolution: {integrity: sha512-CzFnRRXhzWIdItT3OmF8SQfWyahHhjq3HwcMNCNLn+N7klOOqPjMeG/4JSu77D7ypZdGvSzvkrbyeTMizz2VrA==}
@@ -29110,6 +28910,7 @@ packages:
       serialize-javascript: 6.0.1
       terser: 5.26.0
       webpack: 5.89.0(esbuild@0.19.11)
+    dev: true
 
   /terser-webpack-plugin@5.3.10(webpack@5.89.0):
     resolution: {integrity: sha512-BKFPWlPDndPs+NGGCr1U59t0XScL5317Y0UReNrHaw9/FwhPENlq6bfgs+4yPfyP51vqC1bQ4rp1EfXW5ZSH9w==}
@@ -29133,7 +28934,6 @@ packages:
       serialize-javascript: 6.0.1
       terser: 5.26.0
       webpack: 5.89.0
-    dev: false
 
   /terser@5.26.0:
     resolution: {integrity: sha512-dytTGoE2oHgbNV9nTzgBEPaqAWvcJNl66VZ0BkJqlvp71IjO8CxdBx/ykCNb47cLnCmCvRZ6ZR0tLkqvZCdVBQ==}
@@ -29601,7 +29401,6 @@ packages:
     dependencies:
       tslib: 1.14.1
       typescript: 4.9.5
-    dev: false
 
   /tsutils@3.21.0(typescript@5.3.3):
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
@@ -29811,7 +29610,6 @@ packages:
     resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
     engines: {node: '>=4.2.0'}
     hasBin: true
-    dev: false
 
   /typescript@5.3.3:
     resolution: {integrity: sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==}
@@ -30331,7 +30129,7 @@ packages:
       loader-utils: 2.0.4
       mime-types: 2.1.35
       schema-utils: 3.3.0
-      webpack: 5.89.0(esbuild@0.19.11)
+      webpack: 5.89.0
 
   /url@0.11.3:
     resolution: {integrity: sha512-6hxOLGfZASQK/cijlZnZJTq8OXAkt/3YGfQX45vvMYXpZoo8NdWZcY73K108Jf759lS1Bv/8wXnHDTSz17dSRw==}
@@ -31232,7 +31030,7 @@ packages:
       mime-types: 2.1.35
       range-parser: 1.2.1
       schema-utils: 3.3.0
-      webpack: 5.89.0(esbuild@0.19.11)
+      webpack: 5.89.0
 
   /webpack-merge@5.10.0:
     resolution: {integrity: sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==}
@@ -31300,7 +31098,6 @@ packages:
       - '@swc/core'
       - esbuild
       - uglify-js
-    dev: false
 
   /webpack@5.89.0(@swc/core@1.3.102):
     resolution: {integrity: sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==}
@@ -31380,6 +31177,7 @@ packages:
       - '@swc/core'
       - esbuild
       - uglify-js
+    dev: true
 
   /website-scraper@5.3.1:
     resolution: {integrity: sha512-gogqPXD2gVsxoyd2yRiympw3rA5GuEpD1CaDEJ/J8zzanx7hkbTtneoO1SGs436PpLbWVcUge+6APGLhzsuZPA==}


### PR DESCRIPTION
## Description of changes

Upgrade @amazeelabs/executors to 2.0 and address all breaking changes.

## Motivation and context

The previous version of @amazeelabs/executors was unstable due to its use of a global variable as executor registry.
With version 2.0, it has been turned into a proper react context.

## How has this been tested?

- [x] Manually
- [x] Unit tests
- [x] Integration tests
