### PR TITLE
SLB-315: count in-text links references to media entities

### DIFF
--- a/apps/cms/config/sync/entity_usage.settings.yml
+++ b/apps/cms/config/sync/entity_usage.settings.yml
@@ -5,8 +5,8 @@ local_task_enabled_entity_types:
   - node
 track_enabled_source_entity_types:
   - node
-  - content_moderation_state
   - block_content
+  - content_moderation_state
   - menu_link_content
   - media
   - redirect
@@ -14,8 +14,8 @@ track_enabled_source_entity_types:
   - path_alias
 track_enabled_target_entity_types:
   - node
-  - content_moderation_state
   - block_content
+  - content_moderation_state
   - menu_link_content
   - media
   - redirect
@@ -32,6 +32,8 @@ track_enabled_plugins:
   - html_link
   - ckeditor_image
   - block_field
+  - gutenberg_linked_content
+  - gutenberg_referenced_content
   - gutenberg_media_embed
 track_enabled_base_fields: false
 site_domains: {  }

--- a/apps/cms/config/sync/linkit.linkit_profile.gutenberg.yml
+++ b/apps/cms/config/sync/linkit.linkit_profile.gutenberg.yml
@@ -28,6 +28,6 @@ matchers:
       bundles:
         document: document
       group_by_bundle: 0
-      substitution_type: null
+      substitution_type: canonical
       limit: '100'
     weight: -9

--- a/packages/drupal/custom/custom.module
+++ b/packages/drupal/custom/custom.module
@@ -6,6 +6,8 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Language\LanguageInterface;
 use Drupal\Core\Render\Element;
 use Drupal\Core\Render\RenderContext;
+use Drupal\Core\StreamWrapper\LocalStream;
+use Drupal\Core\StreamWrapper\StreamWrapperInterface;
 use Drupal\Core\Utility\Error as ErrorUtil;
 use Drupal\file\Entity\File;
 use Drupal\media\Entity\Media;
@@ -87,6 +89,75 @@ function custom_silverback_gutenberg_link_processor_outbound_url_alter(
         }
       }
     );
+  }
+}
+
+/**
+ * Implements hook_silverback_gutenberg_link_processor_inbound_link_alter().
+ * @param \DOMElement $link
+ * @param \Drupal\silverback_gutenberg\LinkProcessor $linkProcessor
+ *
+ * @return void
+ * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+ * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+ */
+function custom_silverback_gutenberg_link_processor_inbound_link_alter(
+  \DOMElement $link,
+  LinkProcessor $linkProcessor
+) {
+  // For inbound links (when data gets saved), if the link points to a public
+  // file, then we want to replace the href value with "media/uuid/edit" and
+  // also make sure the data-id and data-entity-type attributes have the proper
+  // values (the uuid and the 'media' value). This is a special case for media,
+  // because the url of the media item is replaced by
+  // custom_silverback_gutenberg_link_processor_outbound_url_alter() with the
+  // file path, so now on inbound we need to basically do the opposite. This is
+  // needed so that the entity usage integration works properly (where the
+  // data-id and data-entity-type attributes are checked).
+  $href = $link->getAttribute('href');
+  /* @var \Drupal\Core\StreamWrapper\StreamWrapperManager $wrapperManager */
+  $wrapperManager = \Drupal::service('stream_wrapper_manager');
+  /* @var \Drupal\Core\StreamWrapper\StreamWrapperInterface[] $visibleWrappers */
+  $visibleWrappers = $wrapperManager->getWrappers(StreamWrapperInterface::VISIBLE);
+  foreach ($visibleWrappers as $scheme => $wrapperInfo) {
+    $wrapper = $wrapperManager->getViaScheme($scheme);
+    // We are only handle local streams for now.
+    if (!$wrapper instanceof LocalStream) {
+      continue;
+    }
+    if (!str_starts_with($href, '/' . $wrapper->getDirectoryPath() . '/')) {
+      continue;
+    }
+    // When searching for a file inside the database, the wrapper uri is used
+    // instead of the directory path. That is why we need the wrapper in the
+    // first place.
+    $fileuri = str_replace('/' . $wrapper->getDirectoryPath() . '/', $wrapper->getUri(), urldecode($href));
+    $files = \Drupal::entityTypeManager()
+      ->getStorage('file')
+      ->loadByProperties(['uri' => $fileuri]);
+    // No files found, just continue to the next wrapper.
+    if (empty($files)) {
+      continue;
+    }
+    $file = array_shift($files);
+    $usageList = \Drupal::service('file.usage')->listUsage($file);
+    // If the media file usage list is empty, then this is probably some kind of
+    // orphan file, or tracked by some other entity type.
+    if (empty($usageList['file']['media'])) {
+      continue;
+    }
+    $mids = array_keys($usageList['file']['media']);
+    $mid = reset($mids);
+    $media = Media::load($mid);
+    if (empty($media)) {
+      continue;
+    }
+    // If we got here, we found a matching media item, so we can populate the
+    // link metadata with its values and just break out of the wrappers loop.
+    $link->setAttribute('href', '/media/' . $media->uuid() . '/edit');
+    $link->setAttribute('data-id', $media->uuid());
+    $link->setAttribute('data-entity-type', 'media');
+    break;
   }
 }
 

--- a/packages/drupal/test_content/content/node/25086be7-ca5f-4ff8-9695-b9c71a676d4e.yml
+++ b/packages/drupal/test_content/content/node/25086be7-ca5f-4ff8-9695-b9c71a676d4e.yml
@@ -4,6 +4,8 @@ _meta:
   uuid: 25086be7-ca5f-4ff8-9695-b9c71a676d4e
   bundle: page
   default_langcode: en
+  depends:
+    b998ae5e-8b56-40ca-8f80-fd4404e7e716: media
 default:
   revision_uid:
     -
@@ -47,11 +49,11 @@ default:
 
         <!-- wp:custom/content -->
         <!-- wp:paragraph -->
-        <p><a href="/sites/default/files/2023-04/document_docx.docx" data-type="Media: Document" data-id="b998ae5e-8b56-40ca-8f80-fd4404e7e716">link to file</a></p>
+        <p><a href="/sites/default/files/2023-04/document_docx.docx" data-type="Media: Document" data-id="1" data-entity-type="media">link to file</a></p>
         <!-- /wp:paragraph -->
 
         <!-- wp:paragraph -->
-        <p><a href="/node/50a28359-32f7-48ee-9577-330d79a2b62c" data-type="Content: Basic page" data-id="50a28359-32f7-48ee-9577-330d79a2b62c">link to page</a></p>
+        <p><a href="/node/50a28359-32f7-48ee-9577-330d79a2b62c" data-type="Content: Basic page" data-id="50a28359-32f7-48ee-9577-330d79a2b62c" data-entity-type="node">link to page</a></p>
         <!-- /wp:paragraph -->
         <!-- /wp:custom/content -->
       format: gutenberg

--- a/tests/e2e/specs/drupal/entity-usage.spec.ts
+++ b/tests/e2e/specs/drupal/entity-usage.spec.ts
@@ -1,0 +1,16 @@
+import { expect, test } from '@playwright/test';
+
+import { cmsUrl } from '../../helpers/url';
+
+test.describe('entity-usage', () => {
+  test.use({ storageState: '.auth/admin.json' });
+
+  test('media usage works with inline doc links', async ({ page }) => {
+    await page.goto(cmsUrl('/admin/content/media'));
+    page.locator('div.view-content').getByText('Example DOCX document').click();
+    page.locator('a.tabs__link').getByText('Usage').click();
+    await expect(
+      page.locator('table').getByText('Page with links'),
+    ).toBeVisible();
+  });
+});

--- a/tests/schema/specs/links.spec.ts
+++ b/tests/schema/specs/links.spec.ts
@@ -29,9 +29,9 @@ test('Links', async () => {
             {
               "__typename": "BlockMarkup",
               "markup": "
-    <p><a href="/sites/default/files/2023-04/document_docx.docx" data-type="Media: Document" data-id="[id]">link to file</a></p>
+    <p><a href="/sites/default/files/2023-04/document_docx.docx" data-type="Media: Document" data-id="[id]" data-entity-type="media">link to file</a></p>
 
-    <p><a href="/en/privacy" data-type="Content: Basic page" data-id="[id]">link to page</a></p>
+    <p><a href="/en/privacy" data-type="Content: Basic page" data-id="[id]" data-entity-type="node">link to page</a></p>
     ",
             },
           ],


### PR DESCRIPTION
## Description of changes
In-text link to media references are transformed into urls to the actual file, so the entity usage content link plugin did not count them. Till now.

## Related issue(s)
[Entity reference module to count in-text references to media entities](https://amazeelabs.atlassian.net/browse/SLB-315)

## How has this been tested?
- [x] Manually
- [ ] Unit tests
- [x] Integration tests
