### PR TITLE
Make Publisher work locally

### DIFF
--- a/apps/website/publisher.config.ts
+++ b/apps/website/publisher.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
           // cannot report it.
           // Workaround: Do a double build on the first build.
           'if test -d public; then echo "Single build" && pnpm build:gatsby; else echo "Double build" && pnpm build:gatsby && pnpm build:gatsby; fi'
-        : 'pnpm build:gatsby',
+        : 'DRUPAL_EXTERNAL_URL=http://127.0.0.1:8888 pnpm build:gatsby',
       outputTimeout: 1000 * 60 * 10,
     },
     clean: 'pnpm clean',

--- a/packages/schema/src/image.ts
+++ b/packages/schema/src/image.ts
@@ -26,10 +26,22 @@ export const imageProps: GraphQLFieldResolver<string, any> = (source) => {
   // - If images are processed in Cloudinary, we don't need two CDN's (Netlify & Cloudinary)
   // - TODO: Once we have image processing in Drupal, it has to be handled here.
   if (process.env.NETLIFY_URL && process.env.DRUPAL_EXTERNAL_URL) {
-    return source.replaceAll(
-      process.env.NETLIFY_URL,
-      process.env.DRUPAL_EXTERNAL_URL,
-    );
+    try {
+      const decoded = JSON.parse(source);
+      if (decoded && typeof decoded === 'object') {
+        for (const key in decoded) {
+          if (typeof decoded[key] === 'string') {
+            decoded[key] = decoded[key].replaceAll(
+              process.env.NETLIFY_URL,
+              process.env.DRUPAL_EXTERNAL_URL,
+            );
+          }
+        }
+        return JSON.stringify(decoded);
+      }
+    } catch (error) {
+      return source;
+    }
   }
   return source;
 };


### PR DESCRIPTION
## Motivation and context

```
 ERROR #@amazeelabs/gatsby-source-silverback_gatsby-plugin-sharp-20000  UNKNOWN
Failed to retrieve metadata from image
/Users/alex/work/silverback-template/apps/website/.cache/caches/@amazeelabs/gats
by-source-silverback/5e0f891caa70e3bbaca3c1602206edff/landscape.jpg
  Error: Input buffer contains unsupported image format
  - input.js:486 Sharp.metadata
    [silverback-template]/[sharp@0.33.1]/[sharp]/lib/input.js:486:17
...
```
When running Publisher locally

## How has this been tested?

- [x] Manually
- [ ] Unit tests
- [ ] Integration tests
