### PR TITLE
chore: make publisher work again locally

### DIFF
--- a/apps/website/publisher.config.ts
+++ b/apps/website/publisher.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
           // cannot report it.
           // Workaround: Do a double build on the first build.
           'if test -d public; then echo "Single build" && pnpm build:gatsby; else echo "Double build" && pnpm build:gatsby && pnpm build:gatsby; fi'
-        : 'pnpm build:gatsby',
+        : 'DRUPAL_EXTERNAL_URL=http://127.0.0.1:8888 pnpm build:gatsby',
       outputTimeout: 1000 * 60 * 10,
     },
     clean: 'pnpm clean',


### PR DESCRIPTION
## Motivation and context

- Publisher did not work locally
- It was fixed in https://github.com/AmazeeLabs/silverback-template/pull/179
- The fix was reverted in https://github.com/AmazeeLabs/silverback-template/pull/175/commits/0ecf9d5e9745a60da749eb96bfea4062079047ea

This PR brings it back.


