### PR TITLE
SLB-277 language switcher - DEV

### DIFF
--- a/packages/ui/src/components/Molecules/LanguageSwitcher.tsx
+++ b/packages/ui/src/components/Molecules/LanguageSwitcher.tsx
@@ -1,30 +1,92 @@
 import { Link, Locale, useLocation } from '@custom/schema';
+import { Menu, Transition } from '@headlessui/react';
+import { ChevronDownIcon } from '@heroicons/react/20/solid';
 import clsx from 'clsx';
-import React from 'react';
+import React, { Fragment } from 'react';
 
 import { useTranslations } from '../../utils/translations';
+
+function getLanguageName(locale: string) {
+  const languageNames = new Intl.DisplayNames([locale], {
+    type: 'language',
+  });
+  return languageNames.of(locale);
+}
 
 export function LanguageSwitcher() {
   const translations = useTranslations();
   const [location] = useLocation();
+  const currentLocale = Object.values(Locale).find((locale) => {
+    const translationPath = translations[locale];
+    return location.pathname.includes(translationPath || '');
+  });
+
+  if (!currentLocale) {
+    console.error(
+      'No matching locale found in current path:',
+      location.pathname,
+    );
+    return null;
+  }
+
+  const otherLocales = Object.values(Locale).filter(
+    (locale) => locale !== currentLocale,
+  );
+
   return (
-    <ul className="flex gap-2 uppercase">
-      {Object.values(Locale).map((locale) => (
-        <li key={locale}>
-          {translations[locale] ? (
-            <Link
-              href={translations[locale]!}
-              className={clsx('text-gray-500', {
-                underline: location.pathname !== translations[locale],
-              })}
-            >
-              {locale}
-            </Link>
-          ) : (
-            <span className="text-gray-400">{locale}</span>
-          )}
-        </li>
-      ))}
-    </ul>
+    <div className="relative inline-block text-left">
+      <Menu as="div" className="relative inline-block text-left">
+        <div>
+          <Menu.Button className="inline-flex justify-center w-full rounded-md bg-white text-sm">
+            {getLanguageName(currentLocale as string)}
+            <ChevronDownIcon
+              className="-mr-1 ml-2 h-5 w-5"
+              aria-hidden="true"
+            />
+          </Menu.Button>
+        </div>
+
+        <Transition
+          as={Fragment}
+          enter="transition ease-out duration-100"
+          enterFrom="transform opacity-0 scale-95"
+          enterTo="transform opacity-100 scale-100"
+          leave="transition ease-in duration-75"
+          leaveFrom="transform opacity-100 scale-100"
+          leaveTo="transform opacity-0 scale-95"
+        >
+          <Menu.Items className="origin-top-right absolute right-0 mt-2 w-48 border border-gray-300 rounded-md shadow-lg bg-white">
+            <div className="py-1">
+              {otherLocales.map((locale) => (
+                <Menu.Item key={locale}>
+                  {({ focus }) =>
+                    translations[locale] ? (
+                      <Link
+                        href={translations[locale]!}
+                        className={clsx(
+                          focus ? 'bg-gray-100 text-gray-900' : 'text-gray-700',
+                          'block px-4 py-2 text-sm',
+                        )}
+                      >
+                        {getLanguageName(locale as string)}
+                      </Link>
+                    ) : (
+                      <span
+                        className={clsx(
+                          focus ? 'bg-gray-100 text-gray-900' : 'text-gray-700',
+                          'block px-4 py-2 text-sm',
+                        )}
+                      >
+                        {getLanguageName(locale as string)}
+                      </span>
+                    )
+                  }
+                </Menu.Item>
+              ))}
+            </div>
+          </Menu.Items>
+        </Transition>
+      </Menu>
+    </div>
   );
 }

--- a/packages/ui/src/components/Organisms/Header.tsx
+++ b/packages/ui/src/components/Organisms/Header.tsx
@@ -200,7 +200,7 @@ function UserActions({
   return (
     <div
       className={clsx(
-        'flex w-full justify-end md:py-3.5 md:px-3 0',
+        'flex w-full justify-end md:py-3',
         isDesktop && 'border-b border-gray-300 border-opacity-30',
       )}
     >

--- a/tests/e2e/helpers/quick-actions.ts
+++ b/tests/e2e/helpers/quick-actions.ts
@@ -1,0 +1,23 @@
+import { type Page } from '@playwright/test';
+
+export enum SiteLanguage {
+  English = 'English',
+  Deutsch = 'Deutsch',
+}
+
+export class QuickActions {
+  private page: Page;
+
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  async changeLanguageTo(language: SiteLanguage): Promise<void> {
+    // Open the language switcher.
+    await this.page
+      .locator("(//button[contains(@aria-haspopup, 'menu')])[1]")
+      .click();
+    // look for the language and click on it.
+    await this.page.locator("//a[contains(text(),'" + language + "')]").click();
+  }
+}

--- a/tests/e2e/specs/decap/decap-pages.spec.ts
+++ b/tests/e2e/specs/decap/decap-pages.spec.ts
@@ -12,7 +12,12 @@ test.describe('decap pages', () => {
     await expect(
       content.getByText('This page was created with Decap CMS'),
     ).toBeVisible();
-    await page.getByRole('link', { name: 'de' }).click();
+
+    // Open the language switcher and click on the German language
+    await page.getByRole('button', { name: 'English' }).click();
+    // Think 'getByRole' does not work as item gets removed from the DOM.
+    await page.locator("//a[contains(text(),'Deutsch')]").click();
+
     await expect(
       content.getByRole('heading', { name: 'Decap Beispiel' }),
     ).toBeVisible();

--- a/tests/e2e/specs/decap/decap-pages.spec.ts
+++ b/tests/e2e/specs/decap/decap-pages.spec.ts
@@ -1,9 +1,12 @@
 import { expect, test } from '@playwright/test';
 
 import { websiteUrl } from '../../helpers/url';
+import { QuickActions, SiteLanguage } from '../../helpers/quick-actions';
 
 test.describe('decap pages', () => {
   test('example decap page is rendered', async ({ page }) => {
+    const quickActions = new QuickActions(page);
+
     await page.goto(websiteUrl('/en/decap-example'));
     const content = page.getByRole('main');
     await expect(
@@ -13,10 +16,8 @@ test.describe('decap pages', () => {
       content.getByText('This page was created with Decap CMS'),
     ).toBeVisible();
 
-    // Open the language switcher and click on the German language
-    await page.getByRole('button', { name: 'English' }).click();
-    // Think 'getByRole' does not work as item gets removed from the DOM.
-    await page.locator("//a[contains(text(),'Deutsch')]").click();
+    // Change language to German.
+    await quickActions.changeLanguageTo(SiteLanguage.Deutsch);
 
     await expect(
       content.getByRole('heading', { name: 'Decap Beispiel' }),

--- a/tests/e2e/specs/drupal/content-hub.spec.ts
+++ b/tests/e2e/specs/drupal/content-hub.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '@playwright/test';
 
 import { websiteUrl } from '../../helpers/url';
+import { QuickActions, SiteLanguage } from '../../helpers/quick-actions';
 
 test.describe('content hub', () => {
   test.beforeEach(async ({ page }) => {
@@ -33,8 +34,10 @@ test.describe('content hub', () => {
   });
 
   test('returns language specific results', async ({ page }) => {
+    const quickActions = new QuickActions(page);
     await page.goto(websiteUrl('/en/content-hub'));
-    await page.getByRole('link', { name: 'de' }).click();
+    // Change language to German.
+    await quickActions.changeLanguageTo(SiteLanguage.Deutsch);
     const content = await page.getByRole('main');
     await expect(content.getByText('Architektur')).toBeVisible();
     await expect(content.getByText('Architecture')).not.toBeVisible();

--- a/tests/e2e/specs/drupal/drupal-pages.spec.ts
+++ b/tests/e2e/specs/drupal/drupal-pages.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '@playwright/test';
 
 import { websiteUrl } from '../../helpers/url';
+import { QuickActions, SiteLanguage } from '../../helpers/quick-actions';
 
 test.describe('drupal pages', () => {
   test('example drupal page is rendered', async ({ page }) => {
@@ -11,8 +12,9 @@ test.describe('drupal pages', () => {
     ).toBeVisible();
   });
   test('example drupal page is translated', async ({ page }) => {
+    const quickActions = new QuickActions(page);
     await page.goto(websiteUrl('/en/privacy'));
-    await page.getByRole('link', { name: 'de' }).click();
+    await quickActions.changeLanguageTo(SiteLanguage.Deutsch);
     await expect(
       page.getByRole('heading', { name: 'Privatsphäre' }),
     ).toBeVisible();

--- a/tests/e2e/specs/drupal/homepage.spec.ts
+++ b/tests/e2e/specs/drupal/homepage.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '@playwright/test';
 
 import { websiteUrl } from '../../helpers/url';
+import { QuickActions, SiteLanguage } from '../../helpers/quick-actions';
 
 test.describe('the homepage', () => {
   test('exists in english', async ({ page }) => {
@@ -12,9 +13,10 @@ test.describe('the homepage', () => {
   });
 
   test('exists in german', async ({ page }) => {
+    const quickActions = new QuickActions(page);
     await page.goto(websiteUrl('/en'));
     const content = await page.getByRole('main');
-    await page.getByRole('link', { name: 'de' }).click();
+    await quickActions.changeLanguageTo(SiteLanguage.Deutsch);
     await expect(
       content.getByRole('heading', { name: 'Architektur' }),
     ).toBeVisible();

--- a/tests/e2e/specs/drupal/menus.spec.ts
+++ b/tests/e2e/specs/drupal/menus.spec.ts
@@ -1,25 +1,28 @@
 import { expect, test } from '@playwright/test';
 
 import { websiteUrl } from '../../helpers/url';
+import { QuickActions, SiteLanguage } from '../../helpers/quick-actions';
 
 test.describe('menus', () => {
   test('main navigation', async ({ page }) => {
+    const quickActions = new QuickActions(page);
     await page.goto(websiteUrl('/en'));
     const mainNav = page.getByRole('banner').getByRole('navigation');
     await expect(mainNav.getByText('Architecture')).toBeVisible();
     await expect(mainNav.getByText('Architektur')).not.toBeVisible();
-    await page.getByRole('link', { name: 'de' }).click();
+    await quickActions.changeLanguageTo(SiteLanguage.Deutsch);
     await expect(mainNav.getByText('Architecture')).not.toBeVisible();
     await expect(mainNav.getByText('Gatsby')).not.toBeVisible();
     await expect(mainNav.getByText('Architektur')).toBeVisible();
   });
 
   test('footer navigation', async ({ page }) => {
+    const quickActions = new QuickActions(page);
     await page.goto(websiteUrl('/en'));
     const footerNav = page.getByRole('contentinfo').getByRole('navigation');
     await expect(footerNav.getByText('Privacy')).toBeVisible();
     await expect(footerNav.getByText('Privatsphäre')).not.toBeVisible();
-    await page.getByRole('link', { name: 'de' }).click();
+    await quickActions.changeLanguageTo(SiteLanguage.Deutsch);
     await expect(footerNav.getByText('Privacy')).not.toBeVisible();
     await expect(footerNav.getByText('Privatsphäre')).toBeVisible();
   });


### PR DESCRIPTION
## Description of changes
This PR refactors the LanguageSwitcher component to use Headless UI for creating the dropdown menu. Additionally, it adapts the Header style.

## Motivation and context
The language switcher is currently very bare-bones. It should be the dropdown from the design.
https://amazeelabs.atlassian.net/browse/SLB-277

## How has this been tested?

- [x] Manually
- [ ] Unit tests
- [ ] Integration tests
