### PR TITLE
fix: make init work for website env vars

### DIFF
--- a/apps/website/.lagoon.env
+++ b/apps/website/.lagoon.env
@@ -1,3 +1,4 @@
+PROJECT_NAME=example
 DRUPAL_INTERNAL_URL="http://nginx:8080"
 DRUPAL_EXTERNAL_URL="https://nginx.${LAGOON_ENVIRONMENT}.${LAGOON_PROJECT}.ch4.amazee.io"
 NETLIFY_URL="https://build.${LAGOON_ENVIRONMENT}.${LAGOON_PROJECT}.ch4.amazee.io"
@@ -20,7 +21,7 @@ PUBLISHER_OAUTH2_SESSION_SECRET=REPLACE_ME
 
 # "development" or "production", production will trust first proxy
 # and serve secure cookies.
-PUBLISHER_OAUTH2_ENVIRONMENT_TYPE=production
+PUBLISHER_OAUTH2_ENVIRONMENT_TYPE=development
 
 # DRUPAL_EXTERNAL_URL is used by default, but can be overridden
 # to match the Drupal production url, without the nginx prefix.

--- a/apps/website/.lagoon.env.dev
+++ b/apps/website/.lagoon.env.dev
@@ -1,4 +1,3 @@
-DRUPAL_INTERNAL_URL="http://nginx:8080"
 DRUPAL_EXTERNAL_URL="https://${LAGOON_GIT_BRANCH}-${PROJECT_NAME}.cms.amazeelabs.dev"
 NETLIFY_URL="https://${LAGOON_GIT_BRANCH}-${PROJECT_NAME}.amazeelabs.dev"
 

--- a/apps/website/.lagoon.env.dev
+++ b/apps/website/.lagoon.env.dev
@@ -1,4 +1,3 @@
-PROJECT_NAME=example
 DRUPAL_INTERNAL_URL="http://nginx:8080"
 DRUPAL_EXTERNAL_URL="https://${LAGOON_GIT_BRANCH}-${PROJECT_NAME}.cms.amazeelabs.dev"
 NETLIFY_URL="https://${LAGOON_GIT_BRANCH}-${PROJECT_NAME}.amazeelabs.dev"
@@ -7,22 +6,6 @@ NETLIFY_URL="https://${LAGOON_GIT_BRANCH}-${PROJECT_NAME}.amazeelabs.dev"
 # Publisher authentication with Drupal (OAuth2).
 # See main ./README.md for more information.
 # -----------------------------------------------
-# Set to true to fully skip authentication.
-PUBLISHER_SKIP_AUTHENTICATION=false
-
-# Secret from the Drupal Publisher Consumer.
-PUBLISHER_OAUTH2_CLIENT_SECRET=REPLACE_ME
-
-# Client id from the Drupal Publisher Consumer.
-PUBLISHER_OAUTH2_CLIENT_ID=publisher
-
-# A random string, used to encrypt the session.
-PUBLISHER_OAUTH2_SESSION_SECRET=REPLACE_ME
-
-# "development" or "production", production will trust first proxy
-# and serve secure cookies.
-PUBLISHER_OAUTH2_ENVIRONMENT_TYPE=production
-
 # DRUPAL_EXTERNAL_URL is used by default, but can be overridden
 # to match the Drupal production url, without the nginx prefix.
 PUBLISHER_OAUTH2_TOKEN_HOST="${DRUPAL_EXTERNAL_URL}"

--- a/apps/website/.lagoon.env.prod
+++ b/apps/website/.lagoon.env.prod
@@ -1,4 +1,3 @@
-DRUPAL_INTERNAL_URL="http://nginx:8080"
 DRUPAL_EXTERNAL_URL="https://example.cms.amazeelabs.dev"
 NETLIFY_URL="https://example.amazeelabs.dev"
 

--- a/apps/website/.lagoon.env.prod
+++ b/apps/website/.lagoon.env.prod
@@ -1,4 +1,3 @@
-PROJECT_NAME=example
 DRUPAL_INTERNAL_URL="http://nginx:8080"
 DRUPAL_EXTERNAL_URL="https://example.cms.amazeelabs.dev"
 NETLIFY_URL="https://example.amazeelabs.dev"
@@ -7,18 +6,6 @@ NETLIFY_URL="https://example.amazeelabs.dev"
 # Publisher authentication with Drupal (OAuth2).
 # See main ./README.md for more information.
 # -----------------------------------------------
-# Set to true to fully skip authentication.
-PUBLISHER_SKIP_AUTHENTICATION=false
-
-# Secret from the Drupal Publisher Consumer.
-PUBLISHER_OAUTH2_CLIENT_SECRET=REPLACE_ME
-
-# Client id from the Drupal Publisher Consumer.
-PUBLISHER_OAUTH2_CLIENT_ID=publisher
-
-# A random string, used to encrypt the session.
-PUBLISHER_OAUTH2_SESSION_SECRET=REPLACE_ME
-
 # "development" or "production", production will trust first proxy
 # and serve secure cookies.
 PUBLISHER_OAUTH2_ENVIRONMENT_TYPE=production

--- a/apps/website/.lagoon.env.stage
+++ b/apps/website/.lagoon.env.stage
@@ -1,4 +1,3 @@
-DRUPAL_INTERNAL_URL="http://nginx:8080"
 DRUPAL_EXTERNAL_URL="https://${LAGOON_GIT_BRANCH}-${PROJECT_NAME}.cms.amazeelabs.dev"
 NETLIFY_URL="https://${LAGOON_GIT_BRANCH}-${PROJECT_NAME}.amazeelabs.dev"
 

--- a/apps/website/.lagoon.env.stage
+++ b/apps/website/.lagoon.env.stage
@@ -1,4 +1,3 @@
-PROJECT_NAME=example
 DRUPAL_INTERNAL_URL="http://nginx:8080"
 DRUPAL_EXTERNAL_URL="https://${LAGOON_GIT_BRANCH}-${PROJECT_NAME}.cms.amazeelabs.dev"
 NETLIFY_URL="https://${LAGOON_GIT_BRANCH}-${PROJECT_NAME}.amazeelabs.dev"
@@ -7,18 +6,6 @@ NETLIFY_URL="https://${LAGOON_GIT_BRANCH}-${PROJECT_NAME}.amazeelabs.dev"
 # Publisher authentication with Drupal (OAuth2).
 # See main ./README.md for more information.
 # -----------------------------------------------
-# Set to true to fully skip authentication.
-PUBLISHER_SKIP_AUTHENTICATION=false
-
-# Secret from the Drupal Publisher Consumer.
-PUBLISHER_OAUTH2_CLIENT_SECRET=REPLACE_ME
-
-# Client id from the Drupal Publisher Consumer.
-PUBLISHER_OAUTH2_CLIENT_ID=publisher
-
-# A random string, used to encrypt the session.
-PUBLISHER_OAUTH2_SESSION_SECRET=REPLACE_ME
-
 # "development" or "production", production will trust first proxy
 # and serve secure cookies.
 PUBLISHER_OAUTH2_ENVIRONMENT_TYPE=production


### PR DESCRIPTION
## Description of changes

Move `PROJECT_NAME` and OAuth env vars in main `.lagoon.env`

## Motivation and context

So they can be replaced by `INIT.md` in https://github.com/AmazeeLabs/silverback-template/blob/release/INIT.md?plain=1#L68-L88

Complies with
- https://github.com/AmazeeLabs/silverback-template/blob/release/apps/preview/.lagoon.env
- https://github.com/AmazeeLabs/silverback-template/blob/release/apps/cms/.lagoon.env

## How has this been tested?

- [x] Manually
- [ ] Unit tests
- [ ] Integration tests
