### PR TITLE
chore: bump default php memory limit

### DIFF
--- a/.lagoon/Dockerfile
+++ b/.lagoon/Dockerfile
@@ -60,6 +60,7 @@ COPY --from=builder /tmp/.deploy/cms /app
 
 WORKDIR /app
 ENV WEBROOT=web
+ENV PHP_MEMORY_LIMIT=2048
 
 # ====================================================================================================
 # PHP IMAGE
@@ -73,6 +74,7 @@ COPY --from=cli /app /app
 
 WORKDIR /app
 ENV WEBROOT=web
+ENV PHP_MEMORY_LIMIT=2048
 
 # ====================================================================================================
 # NGINX IMAGE


### PR DESCRIPTION
## Description of changes

Default value is `400M`.

## Motivation and context

- Static builds can be a bottleneck for BE queries executed from the FE
- Improve EX

## How has this been tested?

- [x] Manually
- [ ] Unit tests
- [ ] Integration tests
