### PR TITLE
refactor: simplify menu strucure

### DIFF
--- a/packages/schema/src/schema.graphql
+++ b/packages/schema/src/schema.graphql
@@ -118,24 +118,11 @@ type NavigationItem {
   target: Url! @resolveMenuItemUrl
 }
 
-interface Navigation {
-  locale: Locale!
-  items: [NavigationItem]!
-}
-
-type MetaNavigation implements Navigation @menu(menu_id: "meta") {
+type Navigation {
   locale: Locale! @resolveEntityLanguage
-  items: [NavigationItem]! @lang @resolveMenuItems(max_level: 1)
-}
-
-type MainNavigation implements Navigation @menu(menu_id: "main") {
-  locale: Locale! @resolveEntityLanguage
-  items: [NavigationItem]! @lang @resolveMenuItems
-}
-
-type FooterNavigation implements Navigation @menu(menu_id: "footer") {
-  locale: Locale! @resolveEntityLanguage
-  items: [NavigationItem]! @lang @resolveMenuItems
+  items(max_level: Int): [NavigationItem]!
+    @lang
+    @resolveMenuItems(max_level: "$max_level")
 }
 
 interface Page implements ContentHubResultItem @resolveEntityBundle {
@@ -345,10 +332,9 @@ type Query {
   previewDrupalPage(id: ID!, rid: ID, locale: String!): DrupalPage
     @fetchEntity(type: "node", id: "$id", rid: "$rid", language: "$locale")
 
-  mainNavigations: [MainNavigation] @menuTranslations(menu_id: "main")
-  metaNavigations: [MetaNavigation] @menuTranslations(menu_id: "meta")
-
-  footerNavigations: [FooterNavigation] @menuTranslations(menu_id: "footer")
+  mainNavigations: [Navigation] @menuTranslations(menu_id: "main")
+  metaNavigations: [Navigation] @menuTranslations(menu_id: "meta")
+  footerNavigations: [Navigation] @menuTranslations(menu_id: "footer")
 
   ssgPages(args: String): SSGPagesResult
     @drupalView(id: "ssg_pages:default", args: "$args")

--- a/tests/schema/specs/menu.spec.ts
+++ b/tests/schema/specs/menu.spec.ts
@@ -6,7 +6,7 @@ import { fetch } from '../lib.js';
 test('Meta', async () => {
   const result = await fetch(gql`
     {
-      metaNavigations {
+      metaNavigations(max_level: 1) {
         locale
         items {
           title


### PR DESCRIPTION
## Description of changes

Simplify menus in the GraphQL schema. Having a separate type for each menu was mainly a performance optimization for Gatsby caches.

## Motivation and context

I lost two days to a but that was eventually the wrong menu type.

## How has this been tested?

- [x] Manually
- [x] Unit tests
- [x] Integration tests
