### PR TITLE
fix: set custom heading block for inner accordion item

### DIFF
--- a/packages/drupal/gutenberg_blocks/src/blocks/accordion-item-text.tsx
+++ b/packages/drupal/gutenberg_blocks/src/blocks/accordion-item-text.tsx
@@ -76,7 +76,7 @@ registerBlockType('custom/accordion-item-text', {
             />
             <InnerBlocks
               templateLock={false}
-              allowedBlocks={['core/paragraph', 'core/list', 'core/heading']}
+              allowedBlocks={['core/paragraph', 'core/list', 'custom/heading']}
               template={[['core/paragraph', {}]]}
             />
           </div>


### PR DESCRIPTION
## Description of changes

Use the `custom/heading` block instead of the core one.

## Motivation and context

The `core/heading` block is not discovered

<img width="978" alt="Capture d’écran 2024-08-12 à 10 54 12" src="https://github.com/user-attachments/assets/9dd0ab43-25ec-4aa9-a828-fe09ee8e480b">

Using the custom one works as expected

<img width="982" alt="Capture d’écran 2024-08-12 à 10 54 55" src="https://github.com/user-attachments/assets/cbf94e70-f03e-4a53-960d-814b4cdeb59d">

We might want to use the custom one as mentioned here https://github.com/AmazeeLabs/silverback-template/blob/release/packages/drupal/gutenberg_blocks/src/blocks/heading.tsx#L12-L13

> There is no way to remove formatting options (bold, italic, etc.) from the core/heading block. So we use a custom one.

This is probably why the `core/heading` is removed by another process.
Also, the schema is specifically using `custom/heading` for the body field https://github.com/AmazeeLabs/silverback-template/blob/release/packages/schema/src/schema.graphql#L186

## How has this been tested?

- [x] Manually
- [ ] Unit tests
- [ ] Integration tests
