### PR TITLE
Enable CSS aggregation

### DIFF
--- a/apps/cms/config/sync/system.performance.yml
+++ b/apps/cms/config/sync/system.performance.yml
@@ -4,7 +4,7 @@ cache:
   page:
     max_age: 0
 css:
-  preprocess: false
+  preprocess: true
   gzip: true
 fast_404:
   enabled: true


### PR DESCRIPTION
It is needed to reduce Lagoon hits (costs). It was probably disabled by accident.