### PR TITLE
refactor(preview): oauth improvements

### DIFF
--- a/packages/drupal/custom/custom.deploy.php
+++ b/packages/drupal/custom/custom.deploy.php
@@ -101,6 +101,7 @@ function _custom_deploy_create_consumer(
       'label' => $label,
       'client_id' => $client_id,
       'is_default' => FALSE,
+      'third_party' => FALSE,
       'secret' => $clientSecret,
       'redirect' => $oAuthCallback,
     ])->save();

--- a/packages/ui/src/components/Routes/Preview.tsx
+++ b/packages/ui/src/components/Routes/Preview.tsx
@@ -55,8 +55,8 @@ export function Preview() {
   );
 
   const intl = useIntl();
-  // @todo load this content from Drupal settings, create a ForbiddenPage component.
   // @todo forward error from the backend.
+  // @todo 403 status code.
   const errorMessages = [
     intl.formatMessage({
       defaultMessage:

--- a/packages/ui/src/components/Routes/Preview.tsx
+++ b/packages/ui/src/components/Routes/Preview.tsx
@@ -6,8 +6,8 @@ import React from 'react';
 
 import { clear, useOperation } from '../../utils/operation';
 import { Loading } from '../Molecules/Loading';
-import { PageDisplay } from '../Organisms/PageDisplay';
 import { Messages } from '../Molecules/Messages';
+import { PageDisplay } from '../Organisms/PageDisplay';
 
 function usePreviewParameters(): OperationVariables<
   typeof PreviewDrupalPageQuery

--- a/packages/ui/src/components/Routes/Preview.tsx
+++ b/packages/ui/src/components/Routes/Preview.tsx
@@ -1,17 +1,13 @@
 'use client';
 import { useIntl } from '@amazeelabs/react-intl';
 import type { OperationVariables } from '@custom/schema';
-import {
-  Locale,
-  PreviewDrupalPageQuery,
-  Url,
-  useLocation,
-} from '@custom/schema';
+import { PreviewDrupalPageQuery, useLocation } from '@custom/schema';
 import React from 'react';
 
 import { clear, useOperation } from '../../utils/operation';
 import { Loading } from '../Molecules/Loading';
 import { PageDisplay } from '../Organisms/PageDisplay';
+import { Messages } from '../Molecules/Messages';
 
 function usePreviewParameters(): OperationVariables<
   typeof PreviewDrupalPageQuery
@@ -57,27 +53,17 @@ export function Preview() {
     PreviewDrupalPageQuery,
     usePreviewParameters(),
   );
+
   const intl = useIntl();
   // @todo load this content from Drupal settings, create a ForbiddenPage component.
   // @todo forward error from the backend.
-  const data403 = {
-    preview: {
-      title: '403 Forbidden',
-      locale: 'en' as Locale,
-      translations: [],
-      path: '/403' as Url,
-      content: [
-        {
-          __typename: 'BlockMarkup',
-          markup: `<p>${intl.formatMessage({
-            defaultMessage:
-              'You do not have access to this page. Your access token might have expired.',
-            id: 'iAZszQ',
-          })}</p>`,
-        },
-      ] as Exclude<PreviewDrupalPageQuery['preview'], undefined>['content'],
-    },
-  };
+  const errorMessages = [
+    intl.formatMessage({
+      defaultMessage:
+        'You do not have access to this page. Your access token might have expired.',
+      id: 'iAZszQ',
+    }),
+  ];
   return (
     <>
       {error ? (
@@ -95,7 +81,7 @@ export function Preview() {
               {data?.preview ? (
                 <PageDisplay {...data.preview} />
               ) : (
-                <PageDisplay {...data403.preview} />
+                <Messages messages={errorMessages} />
               )}
             </>
           )}


### PR DESCRIPTION
## Description of changes

- Do not require to grant access for `preview` and `publisher` services, these ones are internal
- Use the message component for error message and remove data dependency that leads to maintenance issues

<img width="576" alt="Capture d’écran 2024-09-30 à 21 28 35" src="https://github.com/user-attachments/assets/a8d8d8e6-45df-4bea-8dc3-84ba5348a184">

## Motivation and context

- Better EX - no need to grant access the first time
- Better DX - remove the binding to fake data for PageDisplay, this was to foresee a given 403 content page but sounds like overhead for a simple message

## How has this been tested?

- [x] Manually
- [ ] Unit tests
- [ ] Integration tests
