### PR TITLE
chore: allow local settings and services override

### DIFF
--- a/apps/cms/scaffold/settings.php.append.txt
+++ b/apps/cms/scaffold/settings.php.append.txt
@@ -69,3 +69,11 @@ if (getenv('LAGOON_ENVIRONMENT') !== 'prod') {
 // Disable key permissions check for Simple OAuth.
 // https://www.drupal.org/project/simple_oauth/issues/3021054
 $settings['simple_oauth.key_permissions_check'] = FALSE;
+
+// Repeat this declaration, so it is possible to override any setting or service.
+if (file_exists(__DIR__ . '/settings.local.php')) {
+  include __DIR__ . '/settings.local.php';
+}
+if (file_exists(__DIR__ . '/services.local.yml')) {
+  $settings['container_yamls'][] = __DIR__ . '/services.local.yml';
+}


### PR DESCRIPTION
## Description of changes

Repeat this declaration at the bottom of `settings.php.append.txt`

```php
if (file_exists(__DIR__ . '/settings.local.php')) {
  include __DIR__ . '/settings.local.php';
}
if (file_exists(__DIR__ . '/services.local.yml')) {
  $settings['container_yamls'][] = __DIR__ . '/services.local.yml';
}
```

I don't think it's an option to use `preprend` as a replacement, because we actually want to override e.g. `settings.lagoon.php` locally (= `SB_ENVIRONMENT`) or on specific environments (dev, stage, prod).

## Motivation and context

Improve DX.
It's technically possible to temporarily override `settings.php` but any change will vanish on `composer install`.

### Use cases

It's common for Drupal devs to just copy `example.settings.local.php` to `settings.local.php` then start own overrides. 

By default, it will enable `development.services.yml` and so turn on verbose error logs, cache tags headers for queries, ... 

Then, it's also possible to set some custom behaviours like
- Use caching just as prod to debug caching issues, or the opposite, turn off all caches
- Re-route email to the developer mailbox by default
- Test CORS configuration
- Test Slack webhook
- Use MySQL database to debug a specific issue
- ...

## How has this been tested?

- [x] Manually
- [ ] Unit tests
- [ ] Integration tests
