### PR TITLE
SLB-469: redirects for RSC files

### DIFF
--- a/apps/website/netlify.toml
+++ b/apps/website/netlify.toml
@@ -9,7 +9,7 @@
   edge_functions = "netlify/edge-functions"
 
 [functions.strangler]
-  included_files = ["dist/public/404.html"]
+  included_files = ["dist/public/404.html", "dist/public/RSC/404.txt"]
 
 [[edge_functions]]
   path = "/"

--- a/apps/website/netlify/functions/strangler.ts
+++ b/apps/website/netlify/functions/strangler.ts
@@ -26,6 +26,7 @@ export const handler = createStrangler(
       url: drupalUrl,
       applies: (url) => url.pathname.startsWith('/RSC/'),
       preprocess: (event) => {
+        // Before handling, turn the RSC url into the corresponding Drupal url.
         event.rawUrl = decodeRSCUrl(event.rawUrl).toString();
         event.path = decodeRSCUrl(event.path).pathname;
         return event;
@@ -38,6 +39,8 @@ export const handler = createStrangler(
               status: response.status,
               headers: {
                 ...response.headers,
+                // After handling, turn the resulting redirect target
+                // into the corresponding RSC url.
                 Location: encodeRSCUrl(location).toString(),
               },
             });

--- a/apps/website/netlify/functions/strangler.ts
+++ b/apps/website/netlify/functions/strangler.ts
@@ -1,15 +1,57 @@
 import { createStrangler } from '@amazeelabs/strangler-netlify';
 import fs from 'fs';
 
+const drupalUrl =
+  process.env.DRUPAL_INTERNAL_URL ||
+  process.env.DRUPAL_EXTERNAL_URL ||
+  'http://127.0.0.1:8888';
+
+function encodeRSCUrl(inputUrl: string) {
+  const url = new URL(inputUrl, 'http://localhost');
+  url.pathname = `/RSC${url.pathname}.txt`;
+  return url;
+}
+
+function decodeRSCUrl(inputUrl: string) {
+  const url = new URL(inputUrl, 'http://localhost');
+  url.pathname = url.pathname.replace(/^\/RSC/, '').replace(/\.txt$/, '');
+  return url;
+}
+
+const notFoundRSC = fs.readFileSync('dist/public/RSC/404.txt').toString();
+
 export const handler = createStrangler(
   [
     {
+      url: drupalUrl,
+      applies: (url) => url.pathname.startsWith('/RSC/'),
+      preprocess: (event) => {
+        event.rawUrl = decodeRSCUrl(event.rawUrl).toString();
+        event.path = decodeRSCUrl(event.path).pathname;
+        return event;
+      },
+      process: (response) => {
+        if ([301, 302].includes(response.status)) {
+          const location = response.headers.get('Location');
+          if (location) {
+            return new Response(response.body, {
+              status: response.status,
+              headers: {
+                ...response.headers,
+                Location: encodeRSCUrl(location).toString(),
+              },
+            });
+          }
+        }
+        return new Response(notFoundRSC, {
+          status: 404,
+        });
+      },
+    },
+    {
       // For Standard drupal redirects, we are interested in any
       // url (therefore no urlFilter) and only in redirects (301, 302).
-      url:
-        process.env.DRUPAL_INTERNAL_URL ||
-        process.env.DRUPAL_EXTERNAL_URL ||
-        'http://127.0.0.1:8888',
+      url: drupalUrl,
       process: (response) =>
         [301, 302].includes(response.status) ? response : undefined,
     },

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -9,7 +9,7 @@
     "@amazeelabs/gatsby-plugin-static-dirs": "^1.0.1",
     "@amazeelabs/gatsby-source-silverback": "^1.14.0",
     "@amazeelabs/publisher": "^2.4.36",
-    "@amazeelabs/strangler-netlify": "^1.1.9",
+    "@amazeelabs/strangler-netlify": "^1.2.1",
     "@amazeelabs/token-auth-middleware": "^1.1.1",
     "@custom/cms": "workspace:*",
     "@custom/decap": "workspace:*",

--- a/apps/website/src/build/redirects.ts
+++ b/apps/website/src/build/redirects.ts
@@ -135,12 +135,13 @@ function writeRedirectsNetlify(config: RedirectsOutputConfig) {
   }
 
   redirectsPool.forEach((value) => {
-    let redirectEntry = `${value.source} ${value.destination} ${value.statusCode}`;
+    let redirectEntry = `\n${value.source} ${value.destination} ${value.statusCode}`;
     if (value.force) {
       redirectEntry += '!';
     }
-    redirectEntry += `
-`;
+    if ([301, 302].includes(value.statusCode)) {
+      redirectEntry += `\n/RSC${value.source}.txt /RSC${value.destination}.txt ${value.statusCode}`;
+    }
 
     fs.appendFileSync(`${config.outputFile}`, redirectEntry);
   });

--- a/packages/ui/src/components/Molecules/Breadcrumbs.tsx
+++ b/packages/ui/src/components/Molecules/Breadcrumbs.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { Link } from '@custom/schema';
+import { Link, Locale } from '@custom/schema';
 import {
   ChevronRightIcon,
   EllipsisHorizontalIcon,
@@ -10,6 +10,9 @@ import React, { useEffect, useState } from 'react';
 import { isTruthy } from '../../utils/isTruthy';
 import { truncateString } from '../../utils/stringTruncation';
 import { useBreadcrumbs } from '../Routes/Menu';
+
+// Paths that lead to the home page and should display the home icon.
+const home_paths = Object.values(Locale).map((locale) => `/${locale}`);
 
 export function BreadCrumbs() {
   const breadcrumbs = useBreadcrumbs();
@@ -97,7 +100,7 @@ export function BreadCrumbs() {
                       'hidden',
                   )}
                 >
-                  {target === '/' && (
+                  {home_paths.includes(target) && (
                     <svg
                       className="w-4 h-4 mr-4"
                       aria-hidden="true"

--- a/packages/ui/src/components/Organisms/Header.tsx
+++ b/packages/ui/src/components/Organisms/Header.tsx
@@ -66,7 +66,10 @@ export function Header() {
             aria-label="Global"
           >
             <div className="flex lg:flex-1">
-              <Link href={'/' as Url} className="-ml-1 mt-1 md:-mt-2.5">
+              <Link
+                href={`/${intl.locale}` as Url}
+                className="-ml-1 mt-1 md:-mt-2.5"
+              >
                 <span className="sr-only">
                   {intl.formatMessage({
                     defaultMessage: 'Company name',

--- a/packages/ui/src/components/Routes/Menu.tsx
+++ b/packages/ui/src/components/Routes/Menu.tsx
@@ -2,6 +2,7 @@ import { useIntl } from '@amazeelabs/react-intl';
 import { FrameQuery, NavigationItem, Url, useLocation } from '@custom/schema';
 
 import { useOperation } from '../../utils/operation';
+import { useLocale } from '../../utils/locale';
 
 export type MenuNameType = 'main' | 'footer';
 
@@ -60,6 +61,7 @@ export function useMenuAncestors(path: string, menuName: MenuNameType) {
   const menuItemFromPath = useMenuItem(path, menuName);
   let processingMenuItem = menuItemFromPath;
   const ancestors: Array<NavigationItem> = [];
+  const locale = useLocale();
 
   // Set current page breadcrumb
   if (typeof processingMenuItem !== 'undefined') {
@@ -81,7 +83,7 @@ export function useMenuAncestors(path: string, menuName: MenuNameType) {
     }
   }
   if (ancestors.length > 0) {
-    ancestors.push({ id: '_', target: '/' as Url, title: 'Home' });
+    ancestors.push({ id: '_', target: `/${locale}` as Url, title: 'Home' });
     // Pop off the current path, we dont care about it
     ancestors.reverse().pop();
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -336,8 +336,8 @@ importers:
         specifier: ^2.4.36
         version: 2.4.36(@types/react@18.3.3)(react@19.0.0-rc-7771d3a7-20240827)(typescript@5.4.5)
       '@amazeelabs/strangler-netlify':
-        specifier: ^1.1.9
-        version: 1.1.9(happy-dom@12.10.3)(react@19.0.0-rc-7771d3a7-20240827)
+        specifier: ^1.2.1
+        version: 1.2.1(react@19.0.0-rc-7771d3a7-20240827)
       '@amazeelabs/token-auth-middleware':
         specifier: ^1.1.1
         version: 1.1.1
@@ -1215,32 +1215,13 @@ packages:
       - react-dom
     dev: false
 
-  /@amazeelabs/strangler-netlify@1.1.9(happy-dom@12.10.3)(react@19.0.0-rc-7771d3a7-20240827):
-    resolution: {integrity: sha512-IOi8nZgf3Lv4hy5/2NIYQlV/gmDij0JBB/LskGfbCAh4mFMaD11OUtKlnzHzVY7HlYsB/dbMvGYJr0NAqpDa0g==}
+  /@amazeelabs/strangler-netlify@1.2.1(react@19.0.0-rc-7771d3a7-20240827):
+    resolution: {integrity: sha512-sMSQZ6wHo591DJ77OHT9iDXU8rskyAGNUxXddb8yTP83VzHOVWf4UBNNJyoZxg3c5CgahXxUAHEqqT7ZRT0z/w==}
     peerDependencies:
       react: 19.0.0-rc-7771d3a7-20240827
     dependencies:
-      '@netlify/functions': 2.6.0
+      '@netlify/functions': 2.8.2
       react: 19.0.0-rc-7771d3a7-20240827
-    optionalDependencies:
-      typescript: 5.4.5
-      vitest: 0.34.6(happy-dom@12.10.3)
-    transitivePeerDependencies:
-      - '@edge-runtime/vm'
-      - '@vitest/browser'
-      - '@vitest/ui'
-      - happy-dom
-      - jsdom
-      - less
-      - lightningcss
-      - playwright
-      - safaridriver
-      - sass
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - webdriverio
     dev: false
 
   /@amazeelabs/token-auth-middleware@1.1.1:
@@ -7676,6 +7657,14 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@netlify/serverless-functions-api': 1.14.0
+    dev: true
+
+  /@netlify/functions@2.8.2:
+    resolution: {integrity: sha512-DeoAQh8LuNPvBE4qsKlezjKj0PyXDryOFJfJKo3Z1qZLKzQ21sT314KQKPVjfvw6knqijj+IO+0kHXy/TJiqNA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@netlify/serverless-functions-api': 1.26.1
+    dev: false
 
   /@netlify/git-utils@5.1.1:
     resolution: {integrity: sha512-oyHieuTZH3rKTmg7EKpGEGa28IFxta2oXuVwpPJI/FJAtBje3UE+yko0eDjNufgm3AyGa8G77trUxgBhInAYuw==}
@@ -7849,6 +7838,15 @@ packages:
     dependencies:
       '@netlify/node-cookies': 0.1.0
       urlpattern-polyfill: 8.0.2
+    dev: true
+
+  /@netlify/serverless-functions-api@1.26.1:
+    resolution: {integrity: sha512-q3L9i3HoNfz0SGpTIS4zTcKBbRkxzCRpd169eyiTuk3IwcPC3/85mzLHranlKo2b+HYT0gu37YxGB45aD8A3Tw==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@netlify/node-cookies': 0.1.0
+      urlpattern-polyfill: 8.0.2
+    dev: false
 
   /@netlify/serverless-functions-api@1.29.0:
     resolution: {integrity: sha512-dSJu+l0tM2Zru9MvDA6ewPwJyU3vYvOUD7jLZyMWvF4arT0X9l+7VIOSaJS8vJDpWhz90ycr1agXv6Uk7+b4uA==}
@@ -20967,6 +20965,7 @@ packages:
       webidl-conversions: 7.0.0
       whatwg-encoding: 2.0.0
       whatwg-mimetype: 3.0.0
+    dev: true
 
   /hard-rejection@2.1.0:
     resolution: {integrity: sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==}
@@ -33165,74 +33164,6 @@ packages:
     dev: false
     optional: true
 
-  /vitest@0.34.6(happy-dom@12.10.3):
-    resolution: {integrity: sha512-+5CALsOvbNKnS+ZHMXtuUC7nL8/7F1F2DnHGjSsszX8zCjWSSviphCb/NuS9Nzf4Q03KyyDRBAXhF/8lffME4Q==}
-    engines: {node: '>=v14.18.0'}
-    hasBin: true
-    requiresBuild: true
-    peerDependencies:
-      '@edge-runtime/vm': '*'
-      '@vitest/browser': '*'
-      '@vitest/ui': '*'
-      happy-dom: '*'
-      jsdom: '*'
-      playwright: '*'
-      safaridriver: '*'
-      webdriverio: '*'
-    peerDependenciesMeta:
-      '@edge-runtime/vm':
-        optional: true
-      '@vitest/browser':
-        optional: true
-      '@vitest/ui':
-        optional: true
-      happy-dom:
-        optional: true
-      jsdom:
-        optional: true
-      playwright:
-        optional: true
-      safaridriver:
-        optional: true
-      webdriverio:
-        optional: true
-    dependencies:
-      '@types/chai': 4.3.14
-      '@types/chai-subset': 1.3.5
-      '@types/node': 18.15.13
-      '@vitest/expect': 0.34.6
-      '@vitest/runner': 0.34.6
-      '@vitest/snapshot': 0.34.6
-      '@vitest/spy': 0.34.6
-      '@vitest/utils': 0.34.6
-      acorn: 8.11.3
-      acorn-walk: 8.3.2
-      cac: 6.7.14
-      chai: 4.4.1
-      debug: 4.3.7
-      happy-dom: 12.10.3
-      local-pkg: 0.4.3
-      magic-string: 0.30.10
-      pathe: 1.1.2
-      picocolors: 1.0.0
-      std-env: 3.7.0
-      strip-literal: 1.3.0
-      tinybench: 2.6.0
-      tinypool: 0.7.0
-      vite: 5.2.8(@types/node@18.15.13)
-      vite-node: 0.34.6(@types/node@18.15.13)
-      why-is-node-running: 2.2.2
-    transitivePeerDependencies:
-      - less
-      - lightningcss
-      - sass
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-    dev: false
-    optional: true
-
   /vitest@1.1.1(@types/node@18.0.0)(@vitest/ui@1.1.1):
     resolution: {integrity: sha512-Ry2qs4UOu/KjpXVfOCfQkTnwSXYGrqTbBZxw6reIYEFjSy1QUARRg5pxiI5BEXy+kBVntxUYNMlq4Co+2vD3fQ==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -33617,6 +33548,7 @@ packages:
   /webidl-conversions@7.0.0:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
+    dev: true
 
   /webpack-dev-middleware@4.3.0(webpack@5.91.0):
     resolution: {integrity: sha512-PjwyVY95/bhBh6VUqt6z4THplYcsvQ8YNNBTBM873xLVmw8FLeALn0qurHbs9EmcfhzQis/eoqypSnZeuUz26w==}
@@ -33773,6 +33705,7 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       iconv-lite: 0.6.3
+    dev: true
 
   /whatwg-fetch@3.6.20:
     resolution: {integrity: sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==}
@@ -33781,6 +33714,7 @@ packages:
   /whatwg-mimetype@3.0.0:
     resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
     engines: {node: '>=12'}
+    dev: true
 
   /whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}

--- a/tests/e2e/helpers/quick-actions.ts
+++ b/tests/e2e/helpers/quick-actions.ts
@@ -13,6 +13,7 @@ export class QuickActions {
   }
 
   async changeLanguageTo(language: SiteLanguage): Promise<void> {
+    await this.page.waitForLoadState('networkidle');
     // Open the language switcher.
     await this.page
       .locator("(//button[contains(@aria-haspopup, 'menu')])[1]")

--- a/tests/e2e/specs/drupal/inquiry.spec.ts
+++ b/tests/e2e/specs/drupal/inquiry.spec.ts
@@ -5,6 +5,7 @@ import { websiteUrl } from '../../helpers/url';
 test.describe('inquiry (mutation example)', () => {
   test('succesfull inquiry submission', async ({ page }) => {
     await page.goto(websiteUrl('/en/inquiry'));
+    await page.waitForLoadState('networkidle');
     const content = await page.getByRole('main');
     await content.getByPlaceholder('Name').fill('John Doe');
     await content.getByPlaceholder('Email').fill('john@doe.com');
@@ -22,6 +23,7 @@ test.describe('inquiry (mutation example)', () => {
 
   test('invalid e-mail address', async ({ page }) => {
     await page.goto(websiteUrl('/en/inquiry'));
+    await page.waitForLoadState('networkidle');
     const content = await page.getByRole('main');
     await content.getByPlaceholder('Name').fill('John Doe');
     await content.getByPlaceholder('Email').fill('john');


### PR DESCRIPTION
## Description of changes

Make sure all redirects have a corresponding redirect for the `/RSC` directory or return the `/RSC/404.txt`.

- [x] redirects created by `redirects.ts` (campaign urls)
- [x] redirects returned by drupal, handled in strangler

## Motivation and context

When a Waku `<Link/>` component targets the path `/test`, it will attempt to load the `/RSC/test.txt` file. If test is a redirect to `/new`, this would fail. By creating a redirect from `/RSC/test.txt` to `/RSC/new.txt`, the `<Link/>` component will be able to load the correct file.

## How has this been tested?

- [x] Manually
- [x] Integration tests
