### PR TITLE
SLB-487: remove the type property from the suggestions query

### DIFF
--- a/packages/drupal/gutenberg_blocks/js/blocks/cta.tsx
+++ b/packages/drupal/gutenberg_blocks/js/blocks/cta.tsx
@@ -116,7 +116,6 @@ registerBlockType<{
               // for 'data-entity-type' in the onChange() handler by yourself.
 
               //suggestionsQuery={{
-              //  type: 'post',
               //  subtype: 'gutenberg',
               //}}
 

--- a/packages/drupal/gutenberg_blocks/js/blocks/teaser-item.tsx
+++ b/packages/drupal/gutenberg_blocks/js/blocks/teaser-item.tsx
@@ -39,7 +39,6 @@ registerBlockType<{
           }}
           settings={{}}
           suggestionsQuery={{
-            type: 'post',
             // Use the teaser_list linkit profile to fetch suggestions.
             subtype: 'teaser_list',
           }}


### PR DESCRIPTION
## Description of changes
Removes the type property from the suggestionsQuery property of the LinkControl item

## Motivation and context
The suggestions rendered by the Gutenberg LinkControl item will not display the Content type metadata if there is only one type specified, see https://github.com/WordPress/gutenberg/issues/24839

## How has this been tested?

- [x] Manually
- [ ] Unit tests
- [ ] Integration tests
