### PR TITLE
fix: re-calculate visibility when the conditions change

### DIFF
--- a/packages/ui/src/components/Organisms/PageContent/BlockConditional.tsx
+++ b/packages/ui/src/components/Organisms/PageContent/BlockConditional.tsx
@@ -18,7 +18,7 @@ export function BlockConditional(props: BlockConditionalFragment) {
       ].every(Boolean),
     };
     setIsActive(Object.values(active).every(Boolean));
-  }, []);
+  }, [props.displayTo, props.displayFrom]);
 
   return isActive ? (
     <>


### PR DESCRIPTION
## Description of changes

Add dependencies to `useEffect` in `ConditionalContent` to make sure it re-renders when the condition properties change.

## Motivation and context

The Preview should reflect condition changes immediately, for demo purposes.
