### PR TITLE
node_modules is messed up by "netlify dev"

### DIFF
--- a/apps/website/.gitignore
+++ b/apps/website/.gitignore
@@ -5,3 +5,6 @@
 public
 styles.css
 persisted-store
+
+# Deno comes with "netlify dev". We don't need its lock file.
+/deno.lock

--- a/apps/website/deno.jsonc
+++ b/apps/website/deno.jsonc
@@ -1,0 +1,10 @@
+// This isn't a Deno project, yet Deno is added by netlify-cli when
+// "netlify dev" is used.
+// This file is picked up by Deno automatically, so we can use it to adjust Deno
+// behavior.
+{
+  // By default, Deno will use node_modules/.deno dir for storing dependencies.
+  // Somehow it messes up node_modules resolution leading to Gatsby build
+  // errors. So we prevent Deno from using node_modules dir.
+  "nodeModulesDir": false,
+}


### PR DESCRIPTION
## Description of changes

Prevent Deno from using node_modules dir.

## Motivation and context

### STR

- Setup the project with `pnpm i && pnpm turbo:prep`
- Start CMS from `apps/cms` with `pnpm dev`
- Start Publisher from `apps/publisher` with `pnpm dev`
- Wait for Publisher to build the website
- Open website at http://localhost:8000/ and wait for the page to load (`netlify dev` needs some time to setup the edge-functions environment)
- Restart Publisher

### Expected behavior

Publisher builds and serves the website

### Actual behavior

The build errors

Error excerpt:
```
$ pnpm dev
...
> gatsby build
...

 ERROR  UNKNOWN

Error in "apps/website/node_modules/.deno/gatsby-plugin-sharp@5.14.0/node_modules/gatsby-plugin-sharp/gatsby-node":
Something went wrong installing the "sharp" module

Cannot find module '../build/Release/sharp-darwin-arm64v8.node'
Require stack:
- apps/website/node_modules/.deno/sharp@0.32.6/node_modules/sharp/lib/sharp.js
...
```

### Possible cause

`netlify dev` sets up Deno environment and Deno installs its packages into `apps/website/node_modules/.deno` messing up pnpm dependencies.

## How has this been tested?

- [x] Manually
- [ ] Unit tests
- [ ] Integration tests

Also deployed to Dev to ensure that it does not break `netlify deploy`