### PR TITLE
Preview draft-only translations

### DIFF
--- a/packages/drupal/custom/src/EventSubscriber/EntityLanguageRedirectSubscriber.php
+++ b/packages/drupal/custom/src/EventSubscriber/EntityLanguageRedirectSubscriber.php
@@ -36,6 +36,28 @@ class EntityLanguageRedirectSubscriber implements EventSubscriberInterface {
   }
 
   public function onKernelRequest(RequestEvent $event): void {
+    $redirect = $this->getMissingDefaultRevisionRedirect($event)
+      ?? $this->getMissingTranslationRedirect($event);
+    if ($redirect) {
+      // Add the necessary cache contexts to the response, as redirect
+      // responses are cached as well.
+      $metadata = new CacheableMetadata();
+      $metadata->addCacheContexts([
+        'languages:language_interface',
+        'url.query_args',
+        'user',
+      ]);
+      $redirect->addCacheableDependency($metadata);
+      if ($this->routeMatch->getRouteName() === 'entity.node.canonical') {
+        $node = $this->routeMatch->getCurrentRouteMatch()->getParameter('node');
+        $redirect->addCacheableDependency($node);
+      }
+
+      $event->setResponse($redirect);
+    }
+  }
+
+  private function getMissingTranslationRedirect(RequestEvent $event): ?TrustedRedirectResponse {
     // In case the user tries to access a node in a language entity is not
     // translated to, we redirect to the entity in the original language and
     // display a warning message.
@@ -57,16 +79,43 @@ class EntityLanguageRedirectSubscriber implements EventSubscriberInterface {
         }
         $urlString = $url->toString() . '?' . $queryString . 'content_language_not_available=true&requested_language=' . $requestedLanguageId;
 
-        // Add the necessary cache contexts to the response, as redirect
-        // responses are cached as well.
-        $metadata = new CacheableMetadata();
-        $metadata->addCacheContexts(['languages:language_interface', 'url.query_args']);
-        $response = new TrustedRedirectResponse($urlString);
-        $response->addCacheableDependency($entity);
-        $response->addCacheableDependency($metadata);
-
-        $event->setResponse($response);
+        return new TrustedRedirectResponse($urlString);
       }
     }
+
+    return NULL;
   }
+
+  private function getMissingDefaultRevisionRedirect(RequestEvent $event): ?TrustedRedirectResponse {
+    // This spaghetti code detects if user is trying to view a translation that
+    // is a draft only and does not have a published revision on the canonical
+    // route.
+    // Why do we do it: The content translation overview page links to
+    // `/{lang}/node/{nid}`, but in the case mentioned above, the canonical
+    // route displays the content in the original language. Which is quite
+    // confusing.
+    if ($this->routeMatch->getRouteName() === 'entity.node.canonical') {
+      $entity = $this->routeMatch->getCurrentRouteMatch()->getParameter('node');
+      $requestedLanguageId = $this->languageManager->getCurrentLanguage(LanguageInterface::TYPE_CONTENT)->getId();
+      if ($entity->language()->getId() != $requestedLanguageId) {
+        $storage = \Drupal::entityTypeManager()->getStorage('node');
+        $latestRevisionId = $storage->getLatestTranslationAffectedRevisionId($entity->id(), $requestedLanguageId);
+        if ($latestRevisionId) {
+          /** @var \Drupal\Core\Entity\ContentEntityInterface $latestRevision */
+          $latestRevision = $storage->loadRevision($latestRevisionId);
+          $translations = $latestRevision->getTranslationLanguages();
+          if (array_key_exists($requestedLanguageId, $translations)) {
+            $latestRevision = $latestRevision->getTranslation($requestedLanguageId);
+            // Bingo! We found the target case. Redirect to the latest revision.
+            if ($latestRevision->access('view')) {
+              $url = $latestRevision->toUrl('latest-version')->toString();
+              return new TrustedRedirectResponse($url);
+            }
+          }
+        }
+      }
+    }
+    return NULL;
+  }
+
 }

--- a/tests/e2e/specs/drupal/content-editing.spec.ts
+++ b/tests/e2e/specs/drupal/content-editing.spec.ts
@@ -23,4 +23,33 @@ test.describe('content-editing', () => {
     //   access
     await expect(page.locator(':text-is("More settings")')).toHaveCount(0);
   });
+
+  test('preview a draft translation', async ({ page }) => {
+    await page.goto(cmsUrl('/en/entity/create/node/page'));
+    await page
+      .getByLabel('Title', { exact: true })
+      .fill('Will have a draft translation');
+    await page.getByLabel('Save as').selectOption('published');
+    await page.getByRole('button', { name: 'Save' }).click();
+    await page.getByLabel('Headline').fill('Will have a draft translation');
+    await page.getByText('Save', { exact: true }).click();
+    await page.getByRole('link', { name: 'Translate' }).click();
+    const translateUrl = page.url();
+    await page.getByRole('link', { name: 'Add', exact: true }).click();
+    await page.getByLabel('Titel', { exact: true }).fill('A draft translation');
+    await page.getByLabel('Ändern in').selectOption('draft');
+    await page.getByLabel('Headline').fill('A draft translation');
+    await page.getByText('Speichern (diese Übersetzung)').click();
+
+    await page.goto(translateUrl);
+    await page
+      .getByRole('link', { name: 'A draft translation', exact: true })
+      .click();
+    await expect(
+      page
+        .frameLocator('iframe')
+        .first()
+        .getByRole('heading', { name: 'A draft translation', exact: true }),
+    ).toBeVisible();
+  });
 });

--- a/tests/e2e/specs/drupal/content-editing.spec.ts
+++ b/tests/e2e/specs/drupal/content-editing.spec.ts
@@ -29,8 +29,8 @@ test.describe('content-editing', () => {
     await page
       .getByLabel('Title', { exact: true })
       .fill('Will have a draft translation');
-    await page.getByLabel('Save as').selectOption('published');
-    await page.getByRole('button', { name: 'Save' }).click();
+    await page.getByRole('button', { name: /Save|Create/ }).click();
+    await page.getByLabel('Change to').selectOption('published');
     await page.getByLabel('Headline').fill('Will have a draft translation');
     await page.getByText('Save', { exact: true }).click();
     await page.getByRole('link', { name: 'Translate' }).click();


### PR DESCRIPTION
## Description of changes

Created a redirect from `/node/123` to `/node/123/latest` for a certain case.

## Motivation and context

Case:
- A page is created in English
- A Draft translation is created in German

The translations overview (`/node/123/translations`) displays the following
- Title of the English translation liked to `/en/node/123`
- Title of the German draft linked to `/de/node/123`

Clicking on `/de/node/123` will display the English page 😢 

The draft content can be reviewed on `/de/node/123/latest`

## How has this been tested?

- [x] Manually
- [ ] Unit tests
- [x] Integration tests

SLB-521
