### PR TITLE
Bake Gutenberg block strings translatable

### DIFF
--- a/packages/drupal/gutenberg_blocks/README.md
+++ b/packages/drupal/gutenberg_blocks/README.md
@@ -173,17 +173,14 @@ pattern.
 - remove the `InnerBlocks` appender when the limit is reached
 
 ```tsx
-/* global Drupal */
 import { registerBlockType } from 'wordpress__blocks';
 import { InnerBlocks } from 'wordpress__block-editor';
 import { useSelect } from 'wordpress__data';
 
-const __ = Drupal.t;
-
 const MAX_BLOCKS: number = 1;
 
 registerBlockType('custom/my-block', {
-  title: __('My Block'),
+  title: Drupal.t('My Block'),
   icon: 'location',
   category: 'layout',
   attributes: {},

--- a/packages/drupal/gutenberg_blocks/js/blocks/accordion-item-text.tsx
+++ b/packages/drupal/gutenberg_blocks/js/blocks/accordion-item-text.tsx
@@ -8,8 +8,6 @@ import {
 import { registerBlockType } from 'wordpress__blocks';
 import { PanelBody, SelectControl } from 'wordpress__components';
 
-const { t: __ } = Drupal;
-
 registerBlockType<{
   title: string;
   icon?: string;
@@ -31,10 +29,10 @@ registerBlockType<{
   edit: (props) => {
     const { attributes, setAttributes, context } = props;
     const icons = [
-      { label: __('- Select an optional icon -'), value: '' },
-      { label: __('Checkmark'), value: 'checkmark' },
-      { label: __('Questionmark'), value: 'questionmark' },
-      { label: __('Arrow'), value: 'arrow' },
+      { label: Drupal.t('- Select an optional icon -'), value: '' },
+      { label: Drupal.t('Checkmark'), value: 'checkmark' },
+      { label: Drupal.t('Questionmark'), value: 'questionmark' },
+      { label: Drupal.t('Arrow'), value: 'arrow' },
     ];
 
     setAttributes({
@@ -46,16 +44,18 @@ registerBlockType<{
     return (
       <Fragment>
         <InspectorControls>
-          <PanelBody title={__('Heading Level')}>
+          <PanelBody title={Drupal.t('Heading Level')}>
             <div>
-              {__('Heading level is defined in the parent accordion block.')}
+              {Drupal.t(
+                'Heading level is defined in the parent accordion block.',
+              )}
             </div>
             <div>
-              {__('Currently it is set to:')}{' '}
+              {Drupal.t('Currently it is set to:')}{' '}
               <strong>{headingLevel as string}</strong>
             </div>
           </PanelBody>
-          <PanelBody title={__('Block settings')}>
+          <PanelBody title={Drupal.t('Block settings')}>
             <SelectControl
               value={attributes.icon}
               options={icons}
@@ -68,7 +68,9 @@ registerBlockType<{
           </PanelBody>
         </InspectorControls>
         <div className={'container-wrapper !border-stone-500'}>
-          <div className={'container-label'}>{__('Accordion Item Text')}</div>
+          <div className={'container-label'}>
+            {Drupal.t('Accordion Item Text')}
+          </div>
           <div
             className={clsx(
               'custom-block-accordion-item-text',
@@ -81,7 +83,7 @@ registerBlockType<{
               value={attributes.title}
               allowedFormats={[]}
               disableLineBreaks={true}
-              placeholder={__('Title')}
+              placeholder={Drupal.t('Title')}
               keepPlaceholderOnFocus={true}
               onChange={(newValue) => {
                 setAttributes({ title: newValue });

--- a/packages/drupal/gutenberg_blocks/js/blocks/accordion.tsx
+++ b/packages/drupal/gutenberg_blocks/js/blocks/accordion.tsx
@@ -2,8 +2,6 @@ import { InnerBlocks, InspectorControls } from 'wordpress__block-editor';
 import { registerBlockType } from 'wordpress__blocks';
 import { PanelBody, SelectControl } from 'wordpress__components';
 
-const { t: __ } = Drupal;
-
 enum HeadingLevels {
   H2 = 'h2',
   H3 = 'h3',
@@ -14,7 +12,7 @@ enum HeadingLevels {
 registerBlockType<{
   headingLevel: string;
 }>('custom/accordion', {
-  title: __('Accordion'),
+  title: Drupal.t('Accordion'),
   icon: 'menu',
   category: 'layout',
   attributes: {
@@ -32,31 +30,31 @@ registerBlockType<{
     return (
       <>
         <InspectorControls>
-          <PanelBody title={__('Heading Level')}>
+          <PanelBody title={Drupal.t('Heading Level')}>
             <SelectControl
               value={attributes.headingLevel}
               options={[
                 {
-                  label: __('Heading 2'),
+                  label: Drupal.t('Heading 2'),
                   value: HeadingLevels.H2,
                 },
                 {
-                  label: __('Heading 3'),
+                  label: Drupal.t('Heading 3'),
                   value: HeadingLevels.H3,
                 },
                 {
-                  label: __('Heading 4'),
+                  label: Drupal.t('Heading 4'),
                   value: HeadingLevels.H4,
                 },
                 {
-                  label: __('Heading 5'),
+                  label: Drupal.t('Heading 5'),
                   value: HeadingLevels.H5,
                 },
               ]}
               onChange={(headingLevel: string) => {
                 setAttributes({ headingLevel });
               }}
-              help={__(
+              help={Drupal.t(
                 'The heading level will be applied to all nested accordion items.',
               )}
             />
@@ -64,7 +62,7 @@ registerBlockType<{
         </InspectorControls>
 
         <div className={'container-wrapper !border-stone-500'}>
-          <div className={'container-label'}>{__('Accordion')}</div>
+          <div className={'container-label'}>{Drupal.t('Accordion')}</div>
           <InnerBlocks
             templateLock={false}
             allowedBlocks={['custom/accordion-item-text']}

--- a/packages/drupal/gutenberg_blocks/js/blocks/conditional.tsx
+++ b/packages/drupal/gutenberg_blocks/js/blocks/conditional.tsx
@@ -9,8 +9,6 @@ import {
   TextControl,
 } from 'wordpress__components';
 
-const { t: __ } = Drupal;
-
 type ConditionsType = {
   [key: string]: {
     label: string;
@@ -19,7 +17,7 @@ type ConditionsType = {
   };
 };
 
-const blockTitle = __('Conditional content');
+const blockTitle = Drupal.t('Conditional content');
 
 registerBlockType<{
   displayFrom: string;
@@ -62,20 +60,20 @@ registerBlockType<{
 
     const conditions: ConditionsType = {
       scheduledDisplay: {
-        label: '⏱️ ' + __('Scheduled display'),
+        label: '⏱️ ' + Drupal.t('Scheduled display'),
         visible: !!(displayFrom || displayTo),
         template: (
           <>
             {displayFrom ? (
               <>
-                <span className="font-extralight">{__('From')}:</span>{' '}
+                <span className="font-extralight">{Drupal.t('From')}:</span>{' '}
                 {new Date(displayFrom).toLocaleString()}
               </>
             ) : null}
             {displayFrom && displayTo ? ' ' : null}
             {displayTo ? (
               <>
-                <span className="font-extralight">{__('To')}:</span>{' '}
+                <span className="font-extralight">{Drupal.t('To')}:</span>{' '}
                 {new Date(displayTo).toLocaleString()}
               </>
             ) : null}
@@ -83,7 +81,7 @@ registerBlockType<{
         ),
       },
       device: {
-        label: '📱 ' + __('Device'),
+        label: '📱 ' + Drupal.t('Device'),
         visible: false,
         template: <>{'Mobile only.'}</>,
       },
@@ -104,7 +102,7 @@ registerBlockType<{
           </>
         ))
     ) : (
-      <>{'ℹ️ ' + __('No conditions set')}</>
+      <>{'ℹ️ ' + Drupal.t('No conditions set')}</>
     );
 
     return (
@@ -123,26 +121,26 @@ registerBlockType<{
           </div>
         </CollapsibleContainer>
         <InspectorControls>
-          <PanelBody title={__('Purpose')}>
+          <PanelBody title={Drupal.t('Purpose')}>
             <PanelRow>
               <TextControl
                 id="purpose"
                 hideLabelFromVision={true}
-                label={__('Purpose')}
+                label={Drupal.t('Purpose')}
                 value={purpose}
                 onChange={(value: string) => setAttributes({ purpose: value })}
-                help={__(
+                help={Drupal.t(
                   'The value is not exposed to the frontend and serves to identify the reason of the conditional content (e.g. Summer Campaign).',
                 )}
               />
             </PanelRow>
           </PanelBody>
 
-          <PanelBody title={__('Scheduled display')}>
+          <PanelBody title={Drupal.t('Scheduled display')}>
             <PanelRow className={'flex flex-col items-start gap-4'}>
               <BaseControl
                 id="displayFrom"
-                label={__('From')}
+                label={Drupal.t('From')}
                 className={
                   '!m-0 [&>div>label]:my-auto [&>div>label]:w-4 [&>div]:flex [&>div]:gap-4'
                 }
@@ -162,7 +160,7 @@ registerBlockType<{
               </BaseControl>
               <BaseControl
                 id="displayTo"
-                label={__('To')}
+                label={Drupal.t('To')}
                 className={
                   '!m-0 [&>div>label]:my-auto [&>div>label]:mb-0 [&>div>label]:w-4 [&>div]:flex [&>div]:gap-4'
                 }
@@ -183,7 +181,7 @@ registerBlockType<{
             </PanelRow>
             <PanelRow>
               <p className={'text-xs text-neutral-500'}>
-                {__('Time zone') +
+                {Drupal.t('Time zone') +
                   ': ' +
                   Intl.DateTimeFormat().resolvedOptions().timeZone}
               </p>

--- a/packages/drupal/gutenberg_blocks/js/blocks/content.tsx
+++ b/packages/drupal/gutenberg_blocks/js/blocks/content.tsx
@@ -1,8 +1,6 @@
 import { InnerBlocks } from 'wordpress__block-editor';
 import { registerBlockType } from 'wordpress__blocks';
 
-const { t: __ } = Drupal;
-
 const style = {
   minHeight: '40px',
   margin: '0 -40px',
@@ -10,7 +8,7 @@ const style = {
 };
 
 registerBlockType<{}>(`custom/content`, {
-  title: __('Content'),
+  title: Drupal.t('Content'),
   category: 'layout',
   icon: 'media-document',
   attributes: {},

--- a/packages/drupal/gutenberg_blocks/js/blocks/cta.tsx
+++ b/packages/drupal/gutenberg_blocks/js/blocks/cta.tsx
@@ -7,7 +7,6 @@ import {
 import { registerBlockType } from 'wordpress__blocks';
 import { PanelBody, SelectControl, ToggleControl } from 'wordpress__components';
 
-const { t: __ } = Drupal;
 const { setPlainTextAttribute } = silverbackGutenbergUtils;
 
 const ArrowRightIcon = () => (
@@ -85,7 +84,7 @@ registerBlockType<{
             value={props.attributes.text}
             allowedFormats={[]}
             disableLineBreaks={true}
-            placeholder={__('Link text')}
+            placeholder={Drupal.t('Link text')}
             keepPlaceholderOnFocus={true}
             style={{
               cursor: 'text',
@@ -98,7 +97,7 @@ registerBlockType<{
             props.attributes.icon === 'ARROW' && <ArrowRightIcon />}
         </a>
         <InspectorControls>
-          <PanelBody title={__('CTA Link')}>
+          <PanelBody title={Drupal.t('CTA Link')}>
             <LinkControl
               value={{
                 url: props.attributes.url,
@@ -141,11 +140,11 @@ registerBlockType<{
               }}
             />
             <ToggleControl
-              label={__('Open in new tab')}
+              label={Drupal.t('Open in new tab')}
               help={
                 props.attributes.openInNewTab
-                  ? __('Opens in a new tab.')
-                  : __('Opens in the same tab.')
+                  ? Drupal.t('Opens in a new tab.')
+                  : Drupal.t('Opens in the same tab.')
               }
               checked={props.attributes.openInNewTab}
               onChange={(openInNewTab) => {
@@ -155,11 +154,11 @@ registerBlockType<{
               }}
             />
             <SelectControl
-              label={__('Icon')}
+              label={Drupal.t('Icon')}
               value={props.attributes.icon}
               options={[
-                { label: __('- None -'), value: 'NONE' },
-                { label: __('Arrow'), value: 'ARROW' },
+                { label: Drupal.t('- None -'), value: 'NONE' },
+                { label: Drupal.t('Arrow'), value: 'ARROW' },
               ]}
               onChange={(icon) => {
                 props.setAttributes({
@@ -170,11 +169,11 @@ registerBlockType<{
             {typeof props.attributes.icon !== 'undefined' &&
               props.attributes.icon !== 'NONE' && (
                 <SelectControl
-                  label={__('Icon position')}
+                  label={Drupal.t('Icon position')}
                   value={props.attributes.iconPosition}
                   options={[
-                    { label: __('After button text'), value: 'AFTER' },
-                    { label: __('Before button text'), value: 'BEFORE' },
+                    { label: Drupal.t('After button text'), value: 'AFTER' },
+                    { label: Drupal.t('Before button text'), value: 'BEFORE' },
                   ]}
                   onChange={(iconPosition) => {
                     props.setAttributes({

--- a/packages/drupal/gutenberg_blocks/js/blocks/demo-block.tsx
+++ b/packages/drupal/gutenberg_blocks/js/blocks/demo-block.tsx
@@ -6,8 +6,6 @@ import { dispatch } from 'wordpress__data';
 
 import { DrupalMediaEntity } from '../utils/drupal-media';
 
-const { t: __ } = Drupal;
-
 registerBlockType<{
   heading: string;
   description: string;
@@ -49,12 +47,12 @@ registerBlockType<{
     return (
       <Fragment>
         <InspectorControls>
-          <PanelBody title={__('Block settings')}>
+          <PanelBody title={Drupal.t('Block settings')}>
             <p>Block settings</p>
           </PanelBody>
         </InspectorControls>
         <div className={'container-wrapper !border-stone-500'}>
-          <div className={'container-label'}>{__('Demo Block')}</div>
+          <div className={'container-label'}>{Drupal.t('Demo Block')}</div>
           <div className="custom-block-demo-block">
             <RichText
               identifier="heading"
@@ -62,7 +60,7 @@ registerBlockType<{
               value={attributes.heading}
               allowedFormats={[]}
               disableLineBreaks={true}
-              placeholder={__('Heading')}
+              placeholder={Drupal.t('Heading')}
               keepPlaceholderOnFocus={true}
               onChange={(newValue) => {
                 setAttributes({ heading: newValue });
@@ -74,7 +72,7 @@ registerBlockType<{
               value={attributes.description}
               allowedFormats={[]}
               disableLineBreaks={true}
-              placeholder={__('Description')}
+              placeholder={Drupal.t('Description')}
               keepPlaceholderOnFocus={true}
               onChange={(newValue) => {
                 setAttributes({ description: newValue });
@@ -100,7 +98,7 @@ registerBlockType<{
               value={attributes.url}
               allowedFormats={[]}
               disableLineBreaks={true}
-              placeholder={__('Url')}
+              placeholder={Drupal.t('Url')}
               keepPlaceholderOnFocus={true}
               onChange={(newValue) => {
                 setAttributes({ url: newValue });

--- a/packages/drupal/gutenberg_blocks/js/blocks/form.tsx
+++ b/packages/drupal/gutenberg_blocks/js/blocks/form.tsx
@@ -2,12 +2,10 @@ import { InnerBlocks, InspectorControls } from 'wordpress__block-editor';
 import { registerBlockType } from 'wordpress__blocks';
 import { PanelBody, SelectControl } from 'wordpress__components';
 
-const { t: __ } = Drupal;
-
 registerBlockType<{
   formId?: string;
 }>(`custom/form`, {
-  title: __('Form'),
+  title: Drupal.t('Form'),
   icon: 'media-document',
   category: 'layout',
   attributes: {
@@ -25,7 +23,7 @@ registerBlockType<{
           <SelectControl
             value={props.attributes.formId}
             options={[
-              { label: __('- Select a form -'), value: '' },
+              { label: Drupal.t('- Select a form -'), value: '' },
               ...drupalSettings.customGutenbergBlocks.forms.map((form) => ({
                 label: form.label,
                 value: form.id,
@@ -40,7 +38,7 @@ registerBlockType<{
         </PanelBody>
       </InspectorControls>
       <div className={'container-wrapper !border-stone-500'}>
-        <div className={'container-label'}>{__('Form')}</div>
+        <div className={'container-label'}>{Drupal.t('Form')}</div>
         {props.attributes.formId ? (
           <iframe
             src={
@@ -51,7 +49,7 @@ registerBlockType<{
             style={{ width: '100%', height: 300, pointerEvents: 'none' }}
           />
         ) : (
-          <p>{__('Please select a form in the sidebar')}</p>
+          <p>{Drupal.t('Please select a form in the sidebar')}</p>
         )}
       </div>
     </>

--- a/packages/drupal/gutenberg_blocks/js/blocks/heading.tsx
+++ b/packages/drupal/gutenberg_blocks/js/blocks/heading.tsx
@@ -4,7 +4,6 @@ import { Path, SVG, ToolbarGroup } from 'wordpress__components';
 
 import { cleanUpText } from '../utils/clean-up-text';
 
-const { t: __ } = Drupal;
 const { sanitizeText } = silverbackGutenbergUtils;
 
 // There is no way to remove formatting options (bold, italic, etc.) from the
@@ -13,7 +12,7 @@ registerBlockType<{
   level: number;
   text: string;
 }>('custom/heading', {
-  title: __('Heading'),
+  title: Drupal.t('Heading'),
   icon: (
     <svg
       width="24"
@@ -79,7 +78,7 @@ registerBlockType<{
               const isActive = level === props.attributes.level;
               return {
                 icon: <HeadingLevelIcon level={level} isPressed={false} />,
-                title: __('Heading @level', { '@level': level }),
+                title: Drupal.t('Heading @level', { '@level': level }),
                 isActive,
                 onClick: () => {
                   props.setAttributes({
@@ -96,7 +95,7 @@ registerBlockType<{
           value={props.attributes.text}
           allowedFormats={['core/bold']}
           disableLineBreaks={true}
-          placeholder={__('Heading')}
+          placeholder={Drupal.t('Heading')}
           keepPlaceholderOnFocus={true}
           onChange={(text) => {
             props.setAttributes({

--- a/packages/drupal/gutenberg_blocks/js/blocks/hero.tsx
+++ b/packages/drupal/gutenberg_blocks/js/blocks/hero.tsx
@@ -10,7 +10,6 @@ import { dispatch } from 'wordpress__data';
 
 import { DrupalMediaEntity } from '../utils/drupal-media';
 
-const { t: __ } = Drupal;
 const { setPlainTextAttribute } = silverbackGutenbergUtils;
 
 registerBlockType<{
@@ -23,7 +22,7 @@ registerBlockType<{
   showLinkControl: boolean;
   formId?: string;
 }>('custom/hero', {
-  title: __('Hero'),
+  title: Drupal.t('Hero'),
   icon: 'cover-image',
   category: 'layout',
   attributes: {
@@ -67,10 +66,10 @@ registerBlockType<{
     return (
       <>
         <InspectorControls>
-          <PanelBody title={__('CTA Link')}>
+          <PanelBody title={Drupal.t('CTA Link')}>
             {!!props.attributes.showLinkControl && (
               <LinkControl
-                placeholder={__('Link')}
+                placeholder={Drupal.t('Link')}
                 value={{
                   url: props.attributes.ctaUrl,
                   openInNewTab: props.attributes.ctaOpenInNewTab,
@@ -100,15 +99,15 @@ registerBlockType<{
                   );
                 }}
               >
-                {__('Remove')}
+                {Drupal.t('Remove')}
               </button>
             )}
           </PanelBody>
-          <PanelBody title={__('Form')}>
+          <PanelBody title={Drupal.t('Form')}>
             <SelectControl
               value={props.attributes.formId}
               options={[
-                { label: __('- Select a form -'), value: '' },
+                { label: Drupal.t('- Select a form -'), value: '' },
                 ...drupalSettings.customGutenbergBlocks.forms.map((form) => ({
                   label: form.label,
                   value: form.id,
@@ -151,7 +150,7 @@ registerBlockType<{
                   value={props.attributes.headline}
                   allowedFormats={[]}
                   disableLineBreaks={true}
-                  placeholder={__('Headline')}
+                  placeholder={Drupal.t('Headline')}
                   keepPlaceholderOnFocus={true}
                   onChange={(headline) => {
                     setPlainTextAttribute(props, 'headline', headline);
@@ -166,7 +165,7 @@ registerBlockType<{
                 value={props.attributes.lead}
                 allowedFormats={[]}
                 disableLineBreaks={true}
-                placeholder={__('Lead text')}
+                placeholder={Drupal.t('Lead text')}
                 keepPlaceholderOnFocus={true}
                 onChange={(lead) => {
                   setPlainTextAttribute(props, 'lead', lead);
@@ -184,7 +183,7 @@ registerBlockType<{
                     value={props.attributes.ctaText}
                     allowedFormats={[]}
                     disableLineBreaks={true}
-                    placeholder={__('CTA text')}
+                    placeholder={Drupal.t('CTA text')}
                     keepPlaceholderOnFocus={true}
                     style={{
                       cursor: 'text',

--- a/packages/drupal/gutenberg_blocks/js/blocks/horizontal-separator.tsx
+++ b/packages/drupal/gutenberg_blocks/js/blocks/horizontal-separator.tsx
@@ -1,9 +1,7 @@
 import { registerBlockType } from 'wordpress__blocks';
 
-const { t: __ } = Drupal;
-
 registerBlockType<{}>(`custom/horizontal-separator`, {
-  title: __('Horizontal separator'),
+  title: Drupal.t('Horizontal separator'),
   icon: 'minus',
   category: 'text',
   attributes: {},

--- a/packages/drupal/gutenberg_blocks/js/blocks/image-teaser.tsx
+++ b/packages/drupal/gutenberg_blocks/js/blocks/image-teaser.tsx
@@ -10,7 +10,6 @@ import { dispatch } from 'wordpress__data';
 
 import { DrupalMediaEntity } from '../utils/drupal-media';
 
-const { t: __ } = Drupal;
 const { setPlainTextAttribute } = silverbackGutenbergUtils;
 
 registerBlockType<{
@@ -19,7 +18,7 @@ registerBlockType<{
   ctaUrl?: string;
   ctaText: string;
 }>('custom/image-teaser', {
-  title: __('Image Teaser'),
+  title: Drupal.t('Image Teaser'),
   parent: ['custom/image-teasers'],
   icon: 'cover-image',
   category: 'layout',
@@ -43,9 +42,9 @@ registerBlockType<{
     return (
       <>
         <InspectorControls>
-          <PanelBody title={__('CTA Link')}>
+          <PanelBody title={Drupal.t('CTA Link')}>
             <LinkControl
-              placeholder={__('Link')}
+              placeholder={Drupal.t('Link')}
               value={{
                 url: props.attributes.ctaUrl,
               }}
@@ -86,7 +85,7 @@ registerBlockType<{
                 value={props.attributes.title}
                 allowedFormats={[]}
                 disableLineBreaks={true}
-                placeholder={__('Title')}
+                placeholder={Drupal.t('Title')}
                 keepPlaceholderOnFocus={true}
                 onChange={(title) => {
                   setPlainTextAttribute(props, 'title', title);
@@ -101,7 +100,7 @@ registerBlockType<{
                 value={props.attributes.ctaText}
                 allowedFormats={[]}
                 disableLineBreaks={true}
-                placeholder={__('CTA text')}
+                placeholder={Drupal.t('CTA text')}
                 keepPlaceholderOnFocus={true}
                 style={{
                   cursor: 'text',

--- a/packages/drupal/gutenberg_blocks/js/blocks/image-teasers.tsx
+++ b/packages/drupal/gutenberg_blocks/js/blocks/image-teasers.tsx
@@ -1,17 +1,15 @@
 import { InnerBlocks } from 'wordpress__block-editor';
 import { registerBlockType } from 'wordpress__blocks';
 
-const { t: __ } = Drupal;
-
 registerBlockType<{}>('custom/image-teasers', {
-  title: __('Image Teasers'),
+  title: Drupal.t('Image Teasers'),
   icon: 'format-image',
   category: 'layout',
   attributes: {},
   edit: () => {
     return (
       <div className={'container-wrapper !border-stone-500'}>
-        <div className={'container-label'}>{__('Image Teasers')}</div>
+        <div className={'container-label'}>{Drupal.t('Image Teasers')}</div>
         <InnerBlocks
           templateLock={false}
           allowedBlocks={['custom/image-teaser']}

--- a/packages/drupal/gutenberg_blocks/js/blocks/image-with-text.tsx
+++ b/packages/drupal/gutenberg_blocks/js/blocks/image-with-text.tsx
@@ -5,13 +5,11 @@ import { dispatch } from 'wordpress__data';
 
 import { DrupalMediaEntity } from '../utils/drupal-media';
 
-const { t: __ } = Drupal;
-
 registerBlockType<{
   mediaEntityIds?: [string];
   imagePosition: string;
 }>('custom/image-with-text', {
-  title: __('Image with Text'),
+  title: Drupal.t('Image with Text'),
   icon: 'cover-image',
   category: 'layout',
   attributes: {
@@ -28,12 +26,12 @@ registerBlockType<{
     return (
       <>
         <InspectorControls>
-          <PanelBody title={__('Image position')}>
+          <PanelBody title={Drupal.t('Image position')}>
             <SelectControl
               value={props.attributes.imagePosition}
               options={[
-                { label: __('Left'), value: 'left' },
-                { label: __('Right'), value: 'right' },
+                { label: Drupal.t('Left'), value: 'left' },
+                { label: Drupal.t('Right'), value: 'right' },
               ]}
               onChange={(imagePosition: string) => {
                 setAttributes({
@@ -44,7 +42,7 @@ registerBlockType<{
           </PanelBody>
         </InspectorControls>
         <div className={'container-wrapper !border-stone-500'}>
-          <div className={'container-label'}>{__('Image with Text')}</div>
+          <div className={'container-label'}>{Drupal.t('Image with Text')}</div>
           <DrupalMediaEntity
             classname={'w-full'}
             attributes={{

--- a/packages/drupal/gutenberg_blocks/js/blocks/info-grid-item.tsx
+++ b/packages/drupal/gutenberg_blocks/js/blocks/info-grid-item.tsx
@@ -8,12 +8,10 @@ import {
   limitedIconListOption,
 } from '../utils/icon-list';
 
-const { t: __ } = Drupal;
-
 registerBlockType<{
   icon: string;
 }>('custom/info-grid-item', {
-  title: __('Info Grid Item'),
+  title: Drupal.t('Info Grid Item'),
   icon: 'align-wide',
   category: 'layout',
   parent: ['custom/info-grid'],
@@ -30,7 +28,7 @@ registerBlockType<{
     return (
       <>
         <InspectorControls>
-          <PanelBody title={__('Select an icon')}>
+          <PanelBody title={Drupal.t('Select an icon')}>
             <SelectControl
               value={props.attributes.icon}
               options={limitedIconListOption([
@@ -46,7 +44,7 @@ registerBlockType<{
         </InspectorControls>
 
         <div className={'container-wrapper !border-stone-500'}>
-          <div className={'container-label'}>{__('Info Grid Item')}</div>
+          <div className={'container-label'}>{Drupal.t('Info Grid Item')}</div>
           <div className={'info-grid-icon'} style={{ maxWidth: '50px' }}>
             {iconPreview && (
               <img src={iconPreview} alt={props.attributes.icon} />

--- a/packages/drupal/gutenberg_blocks/js/blocks/info-grid.tsx
+++ b/packages/drupal/gutenberg_blocks/js/blocks/info-grid.tsx
@@ -2,11 +2,10 @@ import { InnerBlocks } from 'wordpress__block-editor';
 import { registerBlockType } from 'wordpress__blocks';
 import { useSelect } from 'wordpress__data';
 
-const { t: __ } = Drupal;
 const MAX_BLOCKS: number = 3;
 
 registerBlockType<{}>('custom/info-grid', {
-  title: __('Info Grid'),
+  title: Drupal.t('Info Grid'),
   icon: 'editor-insertmore',
   category: 'layout',
   attributes: {},
@@ -18,7 +17,7 @@ registerBlockType<{}>('custom/info-grid', {
 
     return (
       <div className={'container-wrapper !border-stone-500'}>
-        <div className={'container-label'}>{__('Info Grid')}</div>
+        <div className={'container-label'}>{Drupal.t('Info Grid')}</div>
         <InnerBlocks
           templateLock={false}
           renderAppender={() => {

--- a/packages/drupal/gutenberg_blocks/js/blocks/quote.tsx
+++ b/packages/drupal/gutenberg_blocks/js/blocks/quote.tsx
@@ -5,7 +5,6 @@ import { dispatch } from 'wordpress__data';
 import { cleanUpText } from '../utils/clean-up-text';
 import { DrupalMediaEntity } from '../utils/drupal-media';
 
-const { t: __ } = Drupal;
 const { setPlainTextAttribute } = silverbackGutenbergUtils;
 
 registerBlockType<{
@@ -14,7 +13,7 @@ registerBlockType<{
   role: string;
   mediaEntityIds?: [string];
 }>(`custom/quote`, {
-  title: __('Quote'),
+  title: Drupal.t('Quote'),
   icon: 'format-quote',
   category: 'text',
   attributes: {
@@ -58,7 +57,7 @@ registerBlockType<{
             value={props.attributes.quote}
             allowedFormats={['core/bold']}
             disableLineBreaks={false}
-            placeholder={__('Quote')}
+            placeholder={Drupal.t('Quote')}
             keepPlaceholderOnFocus={false}
             onChange={(quote) => {
               props.setAttributes({
@@ -88,7 +87,7 @@ registerBlockType<{
               value={props.attributes.author}
               allowedFormats={[]}
               disableLineBreaks={false}
-              placeholder={__('Author')}
+              placeholder={Drupal.t('Author')}
               keepPlaceholderOnFocus={false}
               onChange={(author) => {
                 setPlainTextAttribute(props, 'author', author);
@@ -101,7 +100,7 @@ registerBlockType<{
               value={props.attributes.role}
               allowedFormats={[]}
               disableLineBreaks={false}
-              placeholder={__('Role')}
+              placeholder={Drupal.t('Role')}
               keepPlaceholderOnFocus={false}
               onChange={(role) => {
                 setPlainTextAttribute(props, 'role', role);

--- a/packages/drupal/gutenberg_blocks/js/blocks/teaser-list.tsx
+++ b/packages/drupal/gutenberg_blocks/js/blocks/teaser-list.tsx
@@ -7,7 +7,6 @@ import {
   ToggleControl,
 } from 'wordpress__components';
 
-const { t: __ } = Drupal;
 const { setPlainTextAttribute } = silverbackGutenbergUtils;
 
 registerBlockType<{
@@ -17,7 +16,7 @@ registerBlockType<{
   limit: number;
   titleFilter: string;
 }>('custom/teaser-list', {
-  title: __('Teaser list'),
+  title: Drupal.t('Teaser list'),
   icon: 'slides',
   category: 'layout',
   attributes: {
@@ -48,15 +47,15 @@ registerBlockType<{
 
     return (
       <div className={'container-wrapper !border-stone-500'}>
-        <div className={'container-label'}>{__('Teaser list')}</div>
+        <div className={'container-label'}>{Drupal.t('Teaser list')}</div>
         <InspectorControls>
           <PanelBody>
             <SelectControl
-              label={__('Layout')}
+              label={Drupal.t('Layout')}
               value={layout}
               options={[
-                { label: __('Grid'), value: 'GRID' },
-                { label: __('Carousel'), value: 'CAROUSEL' },
+                { label: Drupal.t('Grid'), value: 'GRID' },
+                { label: Drupal.t('Carousel'), value: 'CAROUSEL' },
               ]}
               onChange={(layout) => {
                 setAttributes({
@@ -66,17 +65,19 @@ registerBlockType<{
             />
             <TextControl
               value={buttonText}
-              label={__('Button text')}
+              label={Drupal.t('Button text')}
               onChange={(buttonText) => {
                 setPlainTextAttribute(props, 'buttonText', buttonText);
               }}
-              help={__(
+              help={Drupal.t(
                 'A text to show for the read more link. Leave empty to use the default one (Read more).',
               )}
             />
             <ToggleControl
-              label={__('Enable content hub')}
-              help={__('Enable pulling dynamic content from the content hub.')}
+              label={Drupal.t('Enable content hub')}
+              help={Drupal.t(
+                'Enable pulling dynamic content from the content hub.',
+              )}
               checked={contentHubEnabled}
               onChange={(contentHubEnabled) => {
                 setAttributes({
@@ -86,8 +87,8 @@ registerBlockType<{
             />
             {typeof contentHubEnabled !== 'undefined' && contentHubEnabled ? (
               <TextControl
-                label={__('Filter: Title')}
-                help={__('Filter results by title / label.')}
+                label={Drupal.t('Filter: Title')}
+                help={Drupal.t('Filter results by title / label.')}
                 onChange={(titleFilter) => {
                   setAttributes({
                     titleFilter,
@@ -98,8 +99,8 @@ registerBlockType<{
             ) : null}
             {typeof contentHubEnabled !== 'undefined' && contentHubEnabled ? (
               <TextControl
-                label={__('Limit')}
-                help={__(
+                label={Drupal.t('Limit')}
+                help={Drupal.t(
                   'Set a maximum number of results to show from the content hub.',
                 )}
                 onChange={(limit) => {

--- a/packages/drupal/gutenberg_blocks/js/filters/list.tsx
+++ b/packages/drupal/gutenberg_blocks/js/filters/list.tsx
@@ -5,8 +5,6 @@ import { PanelBody, SelectControl } from 'wordpress__components';
 import { createHigherOrderComponent } from 'wordpress__compose';
 import { addFilter } from 'wordpress__hooks';
 
-const { t: __ } = Drupal;
-
 addFilter(
   'blocks.registerBlockType',
   'custom/list',
@@ -41,14 +39,17 @@ addFilter<ComponentType>(
           <BlockEdit {...props} />
           {isSelected && name === 'core/list' && !ordered ? (
             <InspectorControls>
-              <PanelBody title={__('List style')}>
+              <PanelBody title={Drupal.t('List style')}>
                 <SelectControl
                   value={props.attributes.customListStyle}
                   options={[
-                    { label: __('Bullets'), value: '' },
-                    { label: __('Arrows'), value: 'arrows' },
-                    { label: __('Checkmarks'), value: 'checkmarks' },
-                    { label: __('Question marks'), value: 'question-marks' },
+                    { label: Drupal.t('Bullets'), value: '' },
+                    { label: Drupal.t('Arrows'), value: 'arrows' },
+                    { label: Drupal.t('Checkmarks'), value: 'checkmarks' },
+                    {
+                      label: Drupal.t('Question marks'),
+                      value: 'question-marks',
+                    },
                   ]}
                   onChange={(customListStyle: string) => {
                     setAttributes({

--- a/packages/drupal/gutenberg_blocks/js/utils/icon-list.ts
+++ b/packages/drupal/gutenberg_blocks/js/utils/icon-list.ts
@@ -1,5 +1,3 @@
-const { t: __ } = Drupal;
-
 // HOW TO ADD A NEW ICON.
 //
 // 1. Add a new icon to the Icons enum.
@@ -40,7 +38,7 @@ const ICON_IMAGE_PATH = '/modules/custom/gutenberg_blocks/images/icons/';
  */
 export const allIconListOptions = (
   addDefault: boolean = true,
-  defaultLabel: string = __('Select an icon'),
+  defaultLabel: string = Drupal.t('Select an icon'),
   defaultValue: string = '',
 ): Icon[] => {
   // Empty array of icons.
@@ -49,15 +47,15 @@ export const allIconListOptions = (
   // *2. The list of all icons.
   allIcons = [
     {
-      label: __('Email'),
+      label: Drupal.t('Email'),
       value: Icons.EMAIL,
     },
     {
-      label: __('Telephone'),
+      label: Drupal.t('Telephone'),
       value: Icons.PHONE,
     },
     {
-      label: __('Life Ring'),
+      label: Drupal.t('Life Ring'),
       value: Icons.LIFE_RING,
     },
   ];
@@ -116,7 +114,7 @@ export const iconImagePreview = (icon: string): string => {
 export const limitedIconListOption = (
   icons: Icons[],
   addDefault: boolean = true,
-  defaultLabel: string = __('Select an icon'),
+  defaultLabel: string = Drupal.t('Select an icon'),
   defaultValue: string = '',
 ): Icon[] => {
   if (addDefault) {

--- a/packages/drupal/gutenberg_blocks/scripts/generate-gutenberg-block.js
+++ b/packages/drupal/gutenberg_blocks/scripts/generate-gutenberg-block.js
@@ -75,8 +75,6 @@ ${
 import { DrupalMediaEntity } from '../utils/drupal-media';`
 }
 
-const { t: __ } = Drupal;
-
 registerBlockType<{
 ${attributes
   .filter((attribute) => attribute.type)
@@ -112,12 +110,12 @@ ${attributes
     return (
       <Fragment>
         <InspectorControls>
-          <PanelBody title={__('Block settings')}>  
+          <PanelBody title={Drupal.t('Block settings')}>  
             <p>Block settings</p>
           </PanelBody>
         </InspectorControls>
         <div className={'container-wrapper'}>
-          <div className={'container-label'}>{__('${titleCaseTitle}')}</div>
+          <div className={'container-label'}>{Drupal.t('${titleCaseTitle}')}</div>
           <div className="custom-block-${blockName}">
             ${attributes
               .map((attribute) => getGutenbergFieldBlock(attribute))
@@ -146,7 +144,7 @@ function getGutenbergFieldBlock(attribute) {
             allowedFormats={[]}
             // @ts-ignore
             disableLineBreaks={true}
-            placeholder={__("${toTitleCase(attribute.name)}")}
+            placeholder={Drupal.t("${toTitleCase(attribute.name)}")}
             keepPlaceholderOnFocus={true}
             onChange={(newValue) => {
               setAttributes({ ${attribute.name}: newValue })


### PR DESCRIPTION
## Description of changes

Replaced `__('String')` with `Drupal.t('String')`.

## Motivation and context

We used `__('String')` style for historical reasons. But that wasn't picked up by Drupal.

## How has this been tested?

- [x] Manually
- [x] Unit tests
- [ ] Integration tests
