### PR TITLE
Enable locale redirect test

### DIFF
--- a/tests/e2e/specs/drupal/homepage.spec.ts
+++ b/tests/e2e/specs/drupal/homepage.spec.ts
@@ -35,32 +35,18 @@ test.describe('the homepage', () => {
     ).toBeVisible();
   });
 
-  // TODO: Fix this test.
-  //  Current issue:
-  //  In the Playwright traces we see that browser does a request to
-  //  http://127.0.0.1:8000/ with the following headers:
-  //    Host: 127.0.0.1:8000
-  //    Accept-Language: de-DE
-  //  The 301 response headers are:
-  //    location: http://127.0.0.1:8000/en
-  //    server: Netlify
-  //    host: 127.0.0.1:8888
-  //  The most confusing part is the response host - 8888 is the Drupal's port.
-  //  The response for http://127.0.0.1:8000/en does not even have the host
-  //  header.
-  test.fixme(
-    'redirects to german if german is the preferred language',
-    async ({ browser }) => {
-      const context = await browser.newContext({ locale: 'de-DE' });
-      const page = await context.newPage();
-      await page.goto(websiteUrl('/'));
-      const content = page.getByRole('main');
-      await expect(
-        content.getByText('Architektur', { exact: true }),
-      ).toBeVisible();
-      await context.close();
-    },
-  );
+  test('redirects to german if german is the preferred language', async ({
+    browser,
+  }) => {
+    const context = await browser.newContext({ locale: 'de-DE' });
+    const page = await context.newPage();
+    await page.goto(websiteUrl('/'));
+    const content = page.getByRole('main');
+    await expect(
+      content.getByText('Architektur', { exact: true }),
+    ).toBeVisible();
+    await context.close();
+  });
 
   test('it displays an image', async ({ page }) => {
     await page.goto(websiteUrl('/en'));


### PR DESCRIPTION
The test was failing randomly in the past.

Recently we updated all npm dependencies and there's a chance that the test will work reliably now.