### PR TITLE
[Experiment] New block implemented by cursor

### DIFF
--- a/packages/drupal/gutenberg_blocks/js/blocks/person-teaser.tsx
+++ b/packages/drupal/gutenberg_blocks/js/blocks/person-teaser.tsx
@@ -1,0 +1,102 @@
+import { InspectorControls, RichText } from 'wordpress__block-editor';
+import { registerBlockType } from 'wordpress__blocks';
+import { PanelBody } from 'wordpress__components';
+import { dispatch } from 'wordpress__data';
+
+import { DrupalMediaEntity } from '../utils/drupal-media';
+
+const { t: __ } = Drupal;
+const { setPlainTextAttribute } = silverbackGutenbergUtils;
+
+registerBlockType<{
+  mediaEntityIds?: [string];
+  name: string;
+  birthdate: string;
+}>('custom/person-teaser', {
+  title: __('Person Teaser'),
+  icon: 'admin-users',
+  category: 'common',
+  attributes: {
+    mediaEntityIds: {
+      type: 'array',
+    },
+    name: {
+      type: 'string',
+      default: '',
+    },
+    birthdate: {
+      type: 'string',
+      default: '',
+    },
+  },
+  edit: (props) => {
+    const { attributes, setAttributes } = props;
+
+    return (
+      <>
+        <InspectorControls>
+          <PanelBody title={__('Person Settings')}>
+            <div className="components-base-control">
+              <label className="components-base-control__label">
+                {__('Birthdate')}
+              </label>
+              <input
+                type="date"
+                value={attributes.birthdate}
+                onChange={(e) => {
+                  setAttributes({ birthdate: e.target.value });
+                }}
+                className="components-text-control__input"
+              />
+            </div>
+          </PanelBody>
+        </InspectorControls>
+
+        <div className={'container-wrapper !border-stone-500'}>
+          <div className={'container-label'}>{__('Person Teaser')}</div>
+
+          <div className="person-teaser">
+            <div className="person-image">
+              <DrupalMediaEntity
+                classname={'w-full'}
+                attributes={{
+                  ...props.attributes,
+                  lockViewMode: true,
+                  allowedTypes: ['image'],
+                }}
+                setAttributes={props.setAttributes}
+                isMediaLibraryEnabled={true}
+                onError={(error) => {
+                  error = typeof error === 'string' ? error : error[2];
+                  dispatch('core/notices').createWarningNotice(error);
+                }}
+              />
+            </div>
+
+            <div className="person-details">
+              <RichText
+                identifier="name"
+                tagName="h3"
+                value={attributes.name}
+                allowedFormats={[]}
+                placeholder={__('Person Name')}
+                keepPlaceholderOnFocus={true}
+                onChange={(name) => {
+                  setPlainTextAttribute(props, 'name', name);
+                }}
+                className="text-xl font-bold"
+              />
+
+              {attributes.birthdate && (
+                <div className="text-gray-600">
+                  {__('Born')}: {attributes.birthdate}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </>
+    );
+  },
+  save: () => null,
+});

--- a/packages/drupal/gutenberg_blocks/js/index.ts
+++ b/packages/drupal/gutenberg_blocks/js/index.ts
@@ -18,6 +18,7 @@ import './blocks/info-grid';
 import './blocks/info-grid-item';
 import './blocks/teaser-list';
 import './blocks/teaser-item';
+import './blocks/person-teaser';
 
 import { ComponentType } from 'react';
 

--- a/packages/schema/src/fragments/Page.gql
+++ b/packages/schema/src/fragments/Page.gql
@@ -46,6 +46,7 @@ fragment Page on Page {
     ...BlockInfoGrid
     ...BlockTeaserList
     ...BlockConditional
+    ...BlockPersonTeaser
   }
   metaTags {
     tag

--- a/packages/schema/src/fragments/PageContent/BlockConditional.gql
+++ b/packages/schema/src/fragments/PageContent/BlockConditional.gql
@@ -13,5 +13,6 @@ fragment BlockConditional on BlockConditional {
     ...BlockHorizontalSeparator
     ...BlockAccordion
     ...BlockInfoGrid
+    ...BlockPersonTeaser
   }
 }

--- a/packages/schema/src/fragments/PageContent/BlockPersonTeaser.gql
+++ b/packages/schema/src/fragments/PageContent/BlockPersonTeaser.gql
@@ -1,0 +1,8 @@
+fragment BlockPersonTeaser on BlockPersonTeaser {
+  image {
+    source(width: 400, height: 400)
+    alt
+  }
+  name
+  birthdate
+}

--- a/packages/schema/src/schema.graphql
+++ b/packages/schema/src/schema.graphql
@@ -225,6 +225,7 @@ union CommonContent @resolveEditorBlockType =
   | BlockHorizontalSeparator
   | BlockAccordion
   | BlockInfoGrid
+  | BlockPersonTeaser
 
 union PageContent @resolveEditorBlockType =
   | BlockMarkup
@@ -239,6 +240,7 @@ union PageContent @resolveEditorBlockType =
   | BlockInfoGrid
   | BlockTeaserList
   | BlockConditional
+  | BlockPersonTeaser
 
 type BlockForm @type(id: "custom/form") {
   url: Url @resolveEditorBlockAttribute(key: "formId") @webformIdToUrl(id: "$")
@@ -525,4 +527,10 @@ type DrupalTranslatableString implements TranslatableString
   source: String!
   language: Locale!
   translation: String
+}
+
+type BlockPersonTeaser @type(id: "custom/person-teaser") {
+  image: MediaImage @resolveEditorBlockMedia
+  name: String! @resolveEditorBlockAttribute(key: "name")
+  birthdate: String! @resolveEditorBlockAttribute(key: "birthdate")
 }

--- a/packages/ui/src/components/Organisms/PageContent/BlockPersonTeaser.stories.tsx
+++ b/packages/ui/src/components/Organisms/PageContent/BlockPersonTeaser.stories.tsx
@@ -1,0 +1,27 @@
+import Portrait from '@stories/portrait.jpg?as=metadata';
+import { Meta, StoryObj } from '@storybook/react';
+
+import { image } from '../../../helpers/image';
+import { BlockPersonTeaser } from './BlockPersonTeaser';
+
+export default {
+  component: BlockPersonTeaser,
+} satisfies Meta<typeof BlockPersonTeaser>;
+
+export const Default = {
+  args: {
+    name: 'John Doe',
+    birthdate: '1990-01-01',
+    image: {
+      source: image(Portrait),
+      alt: 'John Doe portrait',
+    },
+  },
+} satisfies StoryObj<typeof BlockPersonTeaser>;
+
+export const WithoutImage = {
+  args: {
+    name: 'Jane Smith',
+    birthdate: '1985-06-15',
+  },
+} satisfies StoryObj<typeof BlockPersonTeaser>;

--- a/packages/ui/src/components/Organisms/PageContent/BlockPersonTeaser.tsx
+++ b/packages/ui/src/components/Organisms/PageContent/BlockPersonTeaser.tsx
@@ -1,0 +1,38 @@
+import { BlockPersonTeaserFragment, Image } from '@custom/schema';
+import React from 'react';
+
+import { FadeUp } from '../../Molecules/FadeUp';
+
+export function BlockPersonTeaser(props: BlockPersonTeaserFragment) {
+  return (
+    <FadeUp yGap={50} className="my-10">
+      <div className="container-page">
+        <div className="container-content">
+          <div className="container-text">
+            <div className="flex flex-col items-center space-y-4 rounded-lg bg-gray-50 p-6 text-center shadow-sm md:flex-row md:items-start md:space-x-6 md:space-y-0 md:text-left">
+              {props.image && (
+                <div className="shrink-0">
+                  <Image
+                    source={props.image.source}
+                    alt={props.image.alt}
+                    className="size-32 rounded-full object-cover"
+                  />
+                </div>
+              )}
+              <div className="flex flex-col space-y-2">
+                <h3 className="text-2xl font-bold text-gray-900">
+                  {props.name}
+                </h3>
+                {props.birthdate && (
+                  <p className="text-gray-600">
+                    Born: {new Date(props.birthdate).toLocaleDateString()}
+                  </p>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </FadeUp>
+  );
+}

--- a/packages/ui/src/components/Organisms/PageDisplay.tsx
+++ b/packages/ui/src/components/Organisms/PageDisplay.tsx
@@ -17,6 +17,7 @@ import { BlockImageWithText } from './PageContent/BlockImageWithText';
 import { BlockInfoGrid } from './PageContent/BlockInfoGrid';
 import { BlockMarkup } from './PageContent/BlockMarkup';
 import { BlockMedia } from './PageContent/BlockMedia';
+import { BlockPersonTeaser } from './PageContent/BlockPersonTeaser';
 import { BlockQuote } from './PageContent/BlockQuote';
 import { BlockTeaserList } from './PageContent/BlockTeaserList';
 import { PageHero } from './PageHero';
@@ -54,6 +55,8 @@ export function PageDisplay(page: PageFragment) {
               return <BlockTeaserList key={index} {...block} />;
             case 'BlockConditional':
               return <BlockConditional key={index} {...block} />;
+            case 'BlockPersonTeaser':
+              return <BlockPersonTeaser key={index} {...block} />;
             default:
               throw new UnreachableCaseError(block);
           }
@@ -89,6 +92,8 @@ export function CommonContent(props: CommonContentBlock) {
       return <BlockAccordion {...props} />;
     case 'BlockInfoGrid':
       return <BlockInfoGrid {...props} />;
+    case 'BlockPersonTeaser':
+      return <BlockPersonTeaser {...props} />;
     default:
       throw new UnreachableCaseError(props);
   }


### PR DESCRIPTION
I tried the Composer feature of the Cursor editor.

Initial prompt:
> I have a task for you:
>> Create a new gutenberg block "PersonTeaser" that accepts an image, a name and a birthdate. It should also be added to the graphql schema and output in the frontend.
>
> Before starting the task, find the locations of all files which might be affected. Also, a list of files which can be used as examples.
>
> Ask me if you aren't sure.

It showed the relevant path, but thought that the block's `.ts` file is the frontend. So I added:
> By frontend I meant the UI package.

Then it found all the things and I asked:
> Okay, let's start the implementation

After that I simply clicked `Accept all`

---

Also interesting:
<img src="https://github.com/user-attachments/assets/a4fc3c63-d729-4335-a715-4f6d374ded1f" width="50%" />
