### PR TITLE
Index remote HTML content

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -161,25 +161,42 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
       - name: Setup
         uses: ./.github/actions/setup
+
       - name: TurboRepo local server
         if: ${{ github.event.inputs.turborepo_caching != 'Off' }}
         uses: felixmosh/turborepo-gh-artifacts@v3
         with:
           server-token: 'local'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Test init script
         run:
           pnpm --filter @custom/init run init --project-human-name "Foo Bar"
           --project-machine-name foo_bar | grep 'Run `pnpm i` to update the lock
           file'
+
       - name: Run "pnpm i" to ensure all packages are linked
-        run: pnpm i --no-frozen-lockfile
+        id: package_check
+        run: |
+          set +e
+          output=$(pnpm i --no-frozen-lockfile 2>&1)
+          exit_code=$?
+          echo "$output"
+          if echo "$output" | grep -q "is not in the npm registry"; then
+            echo "Looks like a new @amazeelabs package was added in this PR. Skipping the package link check."
+            echo "should_skip_test=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          exit $exit_code
+
       - name: Run tests (for "test-all/" branches)
         if:
-          startsWith(github.ref_name, 'test-all/') ||
-          startsWith(github.head_ref, 'test-all/')
+          (startsWith(github.ref_name, 'test-all/') ||
+          startsWith(github.head_ref, 'test-all/')) &&
+          steps.package_check.outputs.should_skip_test != 'true'
         run: pnpm turbo:test
         env:
           TURBO_API: 'http://127.0.0.1:9080'

--- a/apps/cms/composer.json
+++ b/apps/cms/composer.json
@@ -48,6 +48,7 @@
     "amazeelabs/silverback_iframe_theme": "*",
     "amazeelabs/silverback_preview_link": "^1.6",
     "amazeelabs/silverback_publisher_monitor": "^2.3.2",
+    "amazeelabs/silverback_search": "*",
     "amazeelabs/silverback_translations": "^1.0.4",
     "composer/installers": "^2.2",
     "drupal/admin_toolbar": ">=3 <4, !=3.5.2",

--- a/apps/cms/composer.lock
+++ b/apps/cms/composer.lock
@@ -4,7 +4,7 @@
     "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
     "This file is @generated automatically"
   ],
-  "content-hash": "f9d786d9df4054b7e829ff8038c67585",
+  "content-hash": "1639922c64f449edb8a4c357475787cc",
   "packages": [
     {
       "name": "amazeeio/drupal_integrations",
@@ -522,6 +522,23 @@
         "source": "https://github.com/AmazeeLabs/silverback_publisher_monitor/tree/2.3.15"
       },
       "time": "2024-09-09T12:01:03+00:00"
+    },
+    {
+      "name": "amazeelabs/silverback_search",
+      "version": "dev-main",
+      "dist": {
+        "type": "path",
+        "url": "node_modules/@amazeelabs/silverback-search/drupal/silverback_search",
+        "reference": "b48d13098258bb98bea81ef0e0fc87a9bc3226a9"
+      },
+      "require": {
+        "symfony/dom-crawler": "^6 || ^7"
+      },
+      "type": "drupal-module",
+      "description": "Search functionality for Silverback.",
+      "transport-options": {
+        "relative": true
+      }
     },
     {
       "name": "amazeelabs/silverback_translations",
@@ -8088,6 +8105,73 @@
         }
       ],
       "time": "2024-09-25T14:20:29+00:00"
+    },
+    {
+      "name": "symfony/dom-crawler",
+      "version": "v6.4.18",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/symfony/dom-crawler.git",
+        "reference": "fd07959d3e8992795029bdab3605c2e8e895034e"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/fd07959d3e8992795029bdab3605c2e8e895034e",
+        "reference": "fd07959d3e8992795029bdab3605c2e8e895034e",
+        "shasum": ""
+      },
+      "require": {
+        "masterminds/html5": "^2.6",
+        "php": ">=8.1",
+        "symfony/polyfill-ctype": "~1.8",
+        "symfony/polyfill-mbstring": "~1.0"
+      },
+      "require-dev": {
+        "symfony/css-selector": "^5.4|^6.0|^7.0"
+      },
+      "type": "library",
+      "autoload": {
+        "psr-4": {
+          "Symfony\\Component\\DomCrawler\\": ""
+        },
+        "exclude-from-classmap": [
+          "/Tests/"
+        ]
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "Fabien Potencier",
+          "email": "fabien@symfony.com"
+        },
+        {
+          "name": "Symfony Community",
+          "homepage": "https://symfony.com/contributors"
+        }
+      ],
+      "description": "Eases DOM navigation for HTML and XML documents",
+      "homepage": "https://symfony.com",
+      "support": {
+        "source": "https://github.com/symfony/dom-crawler/tree/v6.4.18"
+      },
+      "funding": [
+        {
+          "url": "https://symfony.com/sponsor",
+          "type": "custom"
+        },
+        {
+          "url": "https://github.com/fabpot",
+          "type": "github"
+        },
+        {
+          "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+          "type": "tidelift"
+        }
+      ],
+      "time": "2025-01-09T15:35:00+00:00"
     },
     {
       "name": "symfony/error-handler",
@@ -16139,73 +16223,6 @@
         }
       ],
       "time": "2024-09-25T14:18:03+00:00"
-    },
-    {
-      "name": "symfony/dom-crawler",
-      "version": "v6.4.18",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/symfony/dom-crawler.git",
-        "reference": "fd07959d3e8992795029bdab3605c2e8e895034e"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/fd07959d3e8992795029bdab3605c2e8e895034e",
-        "reference": "fd07959d3e8992795029bdab3605c2e8e895034e",
-        "shasum": ""
-      },
-      "require": {
-        "masterminds/html5": "^2.6",
-        "php": ">=8.1",
-        "symfony/polyfill-ctype": "~1.8",
-        "symfony/polyfill-mbstring": "~1.0"
-      },
-      "require-dev": {
-        "symfony/css-selector": "^5.4|^6.0|^7.0"
-      },
-      "type": "library",
-      "autoload": {
-        "psr-4": {
-          "Symfony\\Component\\DomCrawler\\": ""
-        },
-        "exclude-from-classmap": [
-          "/Tests/"
-        ]
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "MIT"
-      ],
-      "authors": [
-        {
-          "name": "Fabien Potencier",
-          "email": "fabien@symfony.com"
-        },
-        {
-          "name": "Symfony Community",
-          "homepage": "https://symfony.com/contributors"
-        }
-      ],
-      "description": "Eases DOM navigation for HTML and XML documents",
-      "homepage": "https://symfony.com",
-      "support": {
-        "source": "https://github.com/symfony/dom-crawler/tree/v6.4.18"
-      },
-      "funding": [
-        {
-          "url": "https://symfony.com/sponsor",
-          "type": "custom"
-        },
-        {
-          "url": "https://github.com/fabpot",
-          "type": "github"
-        },
-        {
-          "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-          "type": "tidelift"
-        }
-      ],
-      "time": "2025-01-09T15:35:00+00:00"
     },
     {
       "name": "symfony/lock",

--- a/apps/cms/config/sync/core.extension.yml
+++ b/apps/cms/config/sync/core.extension.yml
@@ -83,6 +83,7 @@ module:
   silverback_image_ai: 0
   silverback_preview_link: 0
   silverback_publisher_monitor: 0
+  silverback_search: 0
   silverback_translations: 0
   simple_oauth: 0
   slack: 0

--- a/apps/cms/config/sync/search_api.index.global_search.yml
+++ b/apps/cms/config/sync/search_api.index.global_search.yml
@@ -407,6 +407,6 @@ tracker_settings:
 options:
   cron_limit: 50
   delete_on_fail: true
-  index_directly: true
+  index_directly: false
   track_changes_in_references: true
 server: database

--- a/apps/cms/config/sync/search_api.index.global_search.yml
+++ b/apps/cms/config/sync/search_api.index.global_search.yml
@@ -3,10 +3,6 @@ langcode: en
 status: true
 dependencies:
   config:
-    - core.entity_view_mode.config_pages.global_search
-    - core.entity_view_mode.media.global_search
-    - core.entity_view_mode.node.global_search
-    - core.entity_view_mode.user.global_search
     - field.storage.media.field_media_image
     - field.storage.media.field_media_video_file
     - search_api.server.database
@@ -18,6 +14,7 @@ dependencies:
     - path_alias
     - redirect
     - silverback_campaign_urls
+    - silverback_search
     - taxonomy
     - user
 id: global_search
@@ -121,35 +118,33 @@ field_settings:
     dependencies:
       module:
         - redirect
-  rendered_item:
-    label: 'Rendered HTML output'
-    property_path: rendered_item
+  silverback_remote_rendered_item:
+    label: 'Remote rendered HTML output (Silverback)'
+    property_path: silverback_remote_rendered_item
     type: text
     configuration:
-      roles:
-        - editor
-      view_mode:
-        'entity:campaign_url':
-          campaign_url: ''
-        'entity:config_pages':
-          website_settings: global_search
-        'entity:media':
-          document: global_search
-          image: global_search
-          remote_video: global_search
-          video: global_search
-        'entity:menu_link_content':
-          menu_link_content: ''
-        'entity:node':
-          page: global_search
-        'entity:path_alias':
-          path_alias: ''
-        'entity:redirect':
-          redirect: ''
-        'entity:taxonomy_term':
-          taxonomy_term: ''
-        'entity:user':
-          user: global_search
+      root_selector: '#main-content'
+      netlify_password: ''
+      entity_types:
+        node: node
+        block_content: 0
+        config_pages: 0
+        consumer: 0
+        content_moderation_state: 0
+        crop: 0
+        file: 0
+        media: 0
+        menu_link_content: 0
+        path_alias: 0
+        redirect: 0
+        search_api_task: 0
+        shortcut: 0
+        campaign_url: 0
+        silverback_preview_link: 0
+        oauth2_token: 0
+        taxonomy_term: 0
+        user: 0
+        webform_submission: 0
   title:
     label: 'Image » Title'
     datasource_id: 'entity:media'
@@ -246,7 +241,7 @@ processor_settings:
       - menu_name
       - redirect_destination
       - redirect_source
-      - rendered_item
+      - silverback_remote_rendered_item
       - title
       - title_menu_link
     title: true
@@ -275,11 +270,12 @@ processor_settings:
       - menu_name
       - redirect_destination
       - redirect_source
-      - rendered_item
+      - silverback_remote_rendered_item
       - title
       - title_menu_link
   language_with_fallback: {  }
   rendered_item: {  }
+  silverback_remote_rendered_item: {  }
   stopwords:
     weights:
       preprocess_index: -5
@@ -298,7 +294,7 @@ processor_settings:
       - menu_name
       - redirect_destination
       - redirect_source
-      - rendered_item
+      - silverback_remote_rendered_item
       - title
       - title_menu_link
     stopwords:
@@ -355,7 +351,7 @@ processor_settings:
       - menu_name
       - redirect_destination
       - redirect_source
-      - rendered_item
+      - silverback_remote_rendered_item
       - title
       - title_menu_link
     spaces: ''
@@ -380,7 +376,7 @@ processor_settings:
       - menu_name
       - redirect_destination
       - redirect_source
-      - rendered_item
+      - silverback_remote_rendered_item
       - title
       - title_menu_link
   type_boost:
@@ -410,6 +406,7 @@ tracker_settings:
     indexing_order: fifo
 options:
   cron_limit: 50
+  delete_on_fail: true
   index_directly: true
   track_changes_in_references: true
 server: database

--- a/apps/cms/package.json
+++ b/apps/cms/package.json
@@ -29,13 +29,14 @@
   },
   "dependencies": {
     "@amazeelabs/silverback-iframe": "workspace:*",
+    "@amazeelabs/silverback-search": "workspace:^",
     "@custom/custom": "workspace:*",
     "@custom/custom_heavy": "workspace:*",
     "@custom/gutenberg_blocks": "workspace:*",
-    "@custom/schema": "workspace:*",
-    "@custom/test_content": "workspace:*",
-    "@custom/ui": "workspace:*",
     "@custom/preview": "workspace:*",
-    "@custom/search_api_global": "workspace:*"
+    "@custom/schema": "workspace:*",
+    "@custom/search_api_global": "workspace:*",
+    "@custom/test_content": "workspace:*",
+    "@custom/ui": "workspace:*"
   }
 }

--- a/packages/@amazeelabs/silverback-search/drupal/silverback_search/composer.json
+++ b/packages/@amazeelabs/silverback-search/drupal/silverback_search/composer.json
@@ -1,0 +1,9 @@
+{
+  "name": "amazeelabs/silverback_search",
+  "version": "dev-main",
+  "type": "drupal-module",
+  "description": "Search functionality for Silverback.",
+  "require": {
+    "symfony/dom-crawler": "^6 || ^7"
+  }
+}

--- a/packages/@amazeelabs/silverback-search/drupal/silverback_search/silverback_search.info.yml
+++ b/packages/@amazeelabs/silverback-search/drupal/silverback_search/silverback_search.info.yml
@@ -1,0 +1,5 @@
+name: Silverback Search
+type: module
+description: 'Search functionality for Silverback.'
+package: Silverback
+core_version_requirement: ^10 || ^11

--- a/packages/@amazeelabs/silverback-search/drupal/silverback_search/src/Plugin/search_api/processor/Property/RemoteRenderedItemProperty.php
+++ b/packages/@amazeelabs/silverback-search/drupal/silverback_search/src/Plugin/search_api/processor/Property/RemoteRenderedItemProperty.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Drupal\silverback_search\Plugin\search_api\processor\Property;
+
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\search_api\Item\FieldInterface;
+use Drupal\search_api\Processor\ConfigurablePropertyBase;
+
+class RemoteRenderedItemProperty extends ConfigurablePropertyBase {
+
+  use StringTranslationTrait;
+
+  public function defaultConfiguration() {
+    return [
+      'root_selector' => '#main-content',
+      'netlify_password' => '',
+      'entity_types' => [],
+    ];
+  }
+
+  public function buildConfigurationForm(FieldInterface $field, array $form, FormStateInterface $form_state) {
+    $config = $field->getConfiguration() + $this->defaultConfiguration();
+
+    $form['root_selector'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Root CSS Selector'),
+      '#description' => $this->t('CSS selector to define the root of the indexed content (e.g. "#main-content" to exclude menus)'),
+      '#default_value' => $config['root_selector'],
+      '#required' => TRUE,
+    ];
+
+    $form['netlify_password'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Netlify Password'),
+      '#description' => $this->t('Password for Netlify password protection'),
+      '#default_value' => $config['netlify_password'],
+      '#required' => FALSE,
+    ];
+
+    $entity_types = \Drupal::entityTypeManager()->getDefinitions();
+    $content_entity_types = [];
+    foreach ($entity_types as $entity_type_id => $entity_type) {
+      if ($entity_type->entityClassImplements(ContentEntityInterface::class)) {
+        $content_entity_types[$entity_type_id] = $entity_type->getLabel();
+      }
+    }
+    $form['entity_types'] = [
+      '#type' => 'checkboxes',
+      '#title' => $this->t('Entity Types'),
+      '#description' => $this->t('Select which entity types should be processed.'),
+      '#options' => $content_entity_types,
+      '#default_value' => $config['entity_types'],
+    ];
+
+    return $form;
+  }
+
+} 

--- a/packages/@amazeelabs/silverback-search/drupal/silverback_search/src/Plugin/search_api/processor/RemoteRenderedItem.php
+++ b/packages/@amazeelabs/silverback-search/drupal/silverback_search/src/Plugin/search_api/processor/RemoteRenderedItem.php
@@ -198,13 +198,13 @@ class RemoteRenderedItem extends ProcessorPluginBase {
 
   protected function getUpdateCount(string $entityUuid, int $buildId): int {
     return (int) $this->database->select('gatsby_update_log', 'gul')
-      ->countQuery()
       ->condition(
         $this->database->condition('OR')
           ->condition('object_id', $entityUuid)
           ->condition('object_id', $entityUuid . ':%', 'LIKE')
       )
       ->condition('id', $buildId, '>')
+      ->countQuery()
       ->execute()
       ->fetchField();
   }

--- a/packages/@amazeelabs/silverback-search/drupal/silverback_search/src/Plugin/search_api/processor/RemoteRenderedItem.php
+++ b/packages/@amazeelabs/silverback-search/drupal/silverback_search/src/Plugin/search_api/processor/RemoteRenderedItem.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\silverback_search\Plugin\search_api\processor;
 
+use Drupal\Core\Database\Connection;
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\search_api\Datasource\DatasourceInterface;
 use Drupal\search_api\Item\ItemInterface;
@@ -32,16 +33,27 @@ class RemoteRenderedItem extends ProcessorPluginBase {
   protected ExternalPreviewLink $externalPreviewLink;
   protected Client $httpClient;
   protected LoggerInterface $logger;
+  protected Connection $database;
+  
+  private ?int $cachedBuildId = NULL;
 
-  public function __construct(array $configuration, $plugin_id, array $plugin_definition, ExternalPreviewLink $external_preview_link, LoggerInterface $logger) {
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    array $plugin_definition,
+    ExternalPreviewLink $external_preview_link,
+    LoggerInterface $logger,
+    $database
+  ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->externalPreviewLink = $external_preview_link;
+    $this->logger = $logger;
+    $this->database = $database;
     $this->httpClient = new Client([
       RequestOptions::HTTP_ERRORS => FALSE,
       RequestOptions::COOKIES => new CookieJar(),
       RequestOptions::TIMEOUT => 5,
     ]);
-    $this->logger = $logger;
   }
 
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
@@ -50,7 +62,8 @@ class RemoteRenderedItem extends ProcessorPluginBase {
       $plugin_id,
       $plugin_definition,
       $container->get('silverback_external_preview.external_preview_link'),
-      $container->get('logger.factory')->get('silverback_search')
+      $container->get('logger.factory')->get('silverback_search'),
+      $container->get('database'),
     );
   }
 
@@ -84,6 +97,9 @@ class RemoteRenderedItem extends ProcessorPluginBase {
       }
       $html = $this->getHtml($entity, $configuration);
       $field->addValue($html);
+      if ($this->isOutdated($entity)) {
+        $item->addWarning('The remote rendered item is outdated. Marking the search item as dirty.');
+      }
     }
   }
 
@@ -170,6 +186,58 @@ class RemoteRenderedItem extends ProcessorPluginBase {
     }
 
     return '';
+  }
+
+  private function isOutdated(ContentEntityInterface $entity): bool {
+    $buildId = $this->getBuildId();
+    if (!$buildId) {
+      return FALSE;
+    }
+    return $this->getUpdateCount($entity->uuid(), $buildId) > 0;
+  }
+
+  protected function getUpdateCount(string $entityUuid, int $buildId): int {
+    return (int) $this->database->select('gatsby_update_log', 'gul')
+      ->countQuery()
+      ->condition(
+        $this->database->condition('OR')
+          ->condition('object_id', $entityUuid)
+          ->condition('object_id', $entityUuid . ':%', 'LIKE')
+      )
+      ->condition('id', $buildId, '>')
+      ->execute()
+      ->fetchField();
+  }
+
+  private function getBuildId(): ?int {
+    if ($this->cachedBuildId !== NULL) {
+      return $this->cachedBuildId;
+    }
+    try {
+      $buildJsonUrl = $this->externalPreviewLink->getLiveBaseUrl() . '/build.json';
+      $response = $this->httpClient->get($buildJsonUrl);
+      if ($response->getStatusCode() !== 200) {
+        $this->logger->error('Could not check if the remote rendered item is outdated because the build.json response status code is {status_code}. URL: {url}', [
+          'status_code' => $response->getStatusCode(),
+          'url' => $buildJsonUrl,
+        ]);
+        return NULL;
+      }
+      $buildInfo = json_decode($response->getBody()->getContents(), TRUE);
+      if (!isset($buildInfo['drupalBuildId'])) {
+        return NULL;
+      }
+      $buildId = (int) $buildInfo['drupalBuildId'];
+      if (!$buildId) {
+        return NULL;
+      }
+      $this->cachedBuildId = $buildId;
+      return $buildId;
+    }
+    catch (\Throwable $e) {
+      $this->logger->error('Could not fetch build ID: {error}', ['error' => $e->getMessage()]);
+      return NULL;
+    }
   }
 
 }

--- a/packages/@amazeelabs/silverback-search/drupal/silverback_search/src/Plugin/search_api/processor/RemoteRenderedItem.php
+++ b/packages/@amazeelabs/silverback-search/drupal/silverback_search/src/Plugin/search_api/processor/RemoteRenderedItem.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace Drupal\silverback_search\Plugin\search_api\processor;
+
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\search_api\Datasource\DatasourceInterface;
+use Drupal\search_api\Item\ItemInterface;
+use Drupal\search_api\Processor\ProcessorPluginBase;
+use Drupal\silverback_external_preview\ExternalPreviewLink;
+use Drupal\silverback_search\Plugin\search_api\processor\Property\RemoteRenderedItemProperty;
+use GuzzleHttp\Client;
+use GuzzleHttp\Cookie\CookieJar;
+use GuzzleHttp\RequestOptions;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DomCrawler\Crawler;
+
+/**
+ * @SearchApiProcessor(
+ *   id = "silverback_remote_rendered_item",
+ *   label = @Translation("Remote rendered item (Silverback)"),
+ *   description = @Translation("Adds an additional field containing the remotely rendered item."),
+ *   stages = {
+ *     "add_properties" = 0,
+ *   },
+ *   locked = true,
+ *   hidden = true,
+ * )
+ */
+class RemoteRenderedItem extends ProcessorPluginBase {
+
+  protected ExternalPreviewLink $externalPreviewLink;
+  protected Client $httpClient;
+  protected LoggerInterface $logger;
+
+  public function __construct(array $configuration, $plugin_id, array $plugin_definition, ExternalPreviewLink $external_preview_link, LoggerInterface $logger) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->externalPreviewLink = $external_preview_link;
+    $this->httpClient = new Client([
+      RequestOptions::HTTP_ERRORS => FALSE,
+      RequestOptions::COOKIES => new CookieJar(),
+      RequestOptions::TIMEOUT => 5,
+    ]);
+    $this->logger = $logger;
+  }
+
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('silverback_external_preview.external_preview_link'),
+      $container->get('logger.factory')->get('silverback_search')
+    );
+  }
+
+  public function getPropertyDefinitions(?DatasourceInterface $datasource = NULL) {
+    $properties = [];
+
+    if (!$datasource) {
+      $definition = [
+        'label' => $this->t('Remote rendered HTML output (Silverback)'),
+        'description' => $this->t('The complete HTML fetched from remote source'),
+        'type' => 'search_api_html',
+        'processor_id' => $this->getPluginId(),
+      ];
+      $properties['silverback_remote_rendered_item'] = new RemoteRenderedItemProperty($definition);
+    }
+
+    return $properties;
+  }
+
+  public function addFieldValues(ItemInterface $item) {
+    $fields = $this->getFieldsHelper()
+      ->filterForPropertyPath($item->getFields(), NULL, 'silverback_remote_rendered_item');
+    foreach ($fields as $field) {
+      $configuration = $field->getConfiguration();
+      $html = $this->getHtml($item, $configuration);
+      $field->addValue($html);
+    }
+  }
+
+  private function getHtml(ItemInterface $item, array $configuration): string {
+    $entity = $item->getOriginalObject()?->getValue();
+    if (!($entity instanceof ContentEntityInterface)) {
+      return '';
+    }
+    if (!in_array($entity->getEntityTypeId(), $configuration['entity_types'], TRUE)) {
+      return '';
+    }
+    
+    $liveUrl = $this->externalPreviewLink->createPreviewUrlFromEntity($entity, 'live')?->toString();
+    if (!$liveUrl) {
+      return '';
+    }
+
+    $debug = json_encode([
+      'entity_type' => $entity->getEntityTypeId(),
+      'entity_id' => $entity->id(),
+      'live_url' => $liveUrl,
+    ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+    
+    try {
+      $response = $this->httpClient->get($liveUrl);
+      if ($response->getStatusCode() === 401) {
+        if ($configuration['netlify_password']) {
+          $response = $this->httpClient->request('POST', $liveUrl, [
+            RequestOptions::FORM_PARAMS => [
+              'password' => $configuration['netlify_password'],
+            ],
+          ]);
+          if ($response->getStatusCode() === 401) {
+            $this->logger->error(
+              'Could not fetch the remote rendered item because Netlify password is incorrect. Debug:<pre>{debug}</pre>',
+              [
+                'debug' => $debug,
+              ]
+            );
+            return '';
+          }
+        }
+        else {
+          $this->logger->error(
+            'Could not fetch the remote rendered item because Netlify password is not set. Debug:<pre>{debug}</pre>',
+            [
+              'debug' => $debug,
+            ]
+          );
+          return '';
+        }
+      }
+
+      if ($response->getStatusCode() === 200) {
+        $html = $response->getBody()->getContents();
+        $crawler = new Crawler($html);
+        $rootSelector = $configuration['root_selector'] ?: 'body';
+        $filtered = $crawler->filter($rootSelector);
+        if ($filtered->count() > 0) {
+          $html = $filtered->first()->outerHtml();
+          return $html;
+        } else {
+          $this->logger->error(
+            'Root selector `{root_selector}` did not match any elements on the page. Debug:<pre>{debug}</pre>',
+            [
+              'root_selector' => $rootSelector,
+              'debug' => $debug,
+            ]
+          );
+          return '';
+        }
+      } else {
+        $this->logger->error(
+          'Could not fetch the remote rendered item because the response status code is {status_code}. Debug:<pre>{debug}</pre>',
+          [
+            'status_code' => $response->getStatusCode(),
+            'debug' => $debug,
+          ]
+        );
+        return '';
+      }
+    }
+    catch (\Throwable $e) {
+      $this->logger->error(
+        'Could not fetch the remote rendered item because of an error: {error}. Debug:<pre>{debug}</pre>',
+        [
+          'error' => $e->getMessage(),
+          'debug' => $debug,
+        ]
+      );
+      return '';
+    }
+
+    return '';
+  }
+
+}

--- a/packages/@amazeelabs/silverback-search/drupal/silverback_search/src/Plugin/search_api/processor/RemoteRenderedItem.php
+++ b/packages/@amazeelabs/silverback-search/drupal/silverback_search/src/Plugin/search_api/processor/RemoteRenderedItem.php
@@ -36,6 +36,7 @@ class RemoteRenderedItem extends ProcessorPluginBase {
   protected Connection $database;
   
   private ?int $cachedBuildId = NULL;
+  private ?string $cached404PageUuid = NULL;
 
   public function __construct(
     array $configuration,
@@ -95,7 +96,11 @@ class RemoteRenderedItem extends ProcessorPluginBase {
       if (!in_array($entity->getEntityTypeId(), $configuration['entity_types'], TRUE)) {
         continue;
       }
-      $html = $this->getHtml($entity, $configuration);
+      if ($this->is404Page($entity)) {
+        $html = '';
+      } else {
+        $html = $this->getHtml($entity, $configuration);
+      }
       $field->addValue($html);
       if ($this->isOutdated($entity)) {
         $item->addWarning('The remote rendered item is outdated. Marking the search item as dirty.');
@@ -193,7 +198,24 @@ class RemoteRenderedItem extends ProcessorPluginBase {
     if (!$buildId) {
       return FALSE;
     }
-    return $this->getUpdateCount($entity->uuid(), $buildId) > 0;
+    $count = $this->getUpdateCount($entity->uuid(), $buildId);
+    return $count > 0;
+  }
+
+  protected function is404Page(ContentEntityInterface $entity): bool {
+    if ($this->cached404PageUuid === NULL) {
+      try {
+        $this->cached404PageUuid = config_pages_config('website_settings')
+          ->get('field_404_page')
+          ->entity
+          ->uuid();
+      }
+      catch (\Exception $e) {
+        $this->logger->error('Error getting 404 page from website_settings: {error}', ['error' => $e->getMessage()]);
+        return FALSE;
+      }
+    }
+    return $entity->uuid() === $this->cached404PageUuid;
   }
 
   protected function getUpdateCount(string $entityUuid, int $buildId): int {

--- a/packages/@amazeelabs/silverback-search/drupal/silverback_search/src/Plugin/search_api/processor/RemoteRenderedItem.php
+++ b/packages/@amazeelabs/silverback-search/drupal/silverback_search/src/Plugin/search_api/processor/RemoteRenderedItem.php
@@ -75,20 +75,19 @@ class RemoteRenderedItem extends ProcessorPluginBase {
       ->filterForPropertyPath($item->getFields(), NULL, 'silverback_remote_rendered_item');
     foreach ($fields as $field) {
       $configuration = $field->getConfiguration();
-      $html = $this->getHtml($item, $configuration);
+      $entity = $item->getOriginalObject()?->getValue();
+      if (!($entity instanceof ContentEntityInterface)) {
+        continue;
+      }
+      if (!in_array($entity->getEntityTypeId(), $configuration['entity_types'], TRUE)) {
+        continue;
+      }
+      $html = $this->getHtml($entity, $configuration);
       $field->addValue($html);
     }
   }
 
-  private function getHtml(ItemInterface $item, array $configuration): string {
-    $entity = $item->getOriginalObject()?->getValue();
-    if (!($entity instanceof ContentEntityInterface)) {
-      return '';
-    }
-    if (!in_array($entity->getEntityTypeId(), $configuration['entity_types'], TRUE)) {
-      return '';
-    }
-    
+  private function getHtml(ContentEntityInterface $entity, array $configuration): string {
     $liveUrl = $this->externalPreviewLink->createPreviewUrlFromEntity($entity, 'live')?->toString();
     if (!$liveUrl) {
       return '';

--- a/packages/@amazeelabs/silverback-search/drupal/silverback_search/tests/src/Unit/Plugin/search_api/processor/RemoteRenderedItemTest.php
+++ b/packages/@amazeelabs/silverback-search/drupal/silverback_search/tests/src/Unit/Plugin/search_api/processor/RemoteRenderedItemTest.php
@@ -1,0 +1,243 @@
+<?php
+
+namespace Drupal\Tests\silverback_search\Unit\Plugin\search_api\processor;
+
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Url;
+use Drupal\search_api\Item\ItemInterface;
+use Drupal\silverback_external_preview\ExternalPreviewLink;
+use Drupal\silverback_search\Plugin\search_api\processor\RemoteRenderedItem;
+use Drupal\Tests\UnitTestCase;
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\RequestOptions;
+use Psr\Log\LoggerInterface;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Argument;
+
+class RemoteRenderedItemTest extends UnitTestCase {
+  use ProphecyTrait;
+
+  /**
+   * @dataProvider getHtmlProvider
+   * @covers \Drupal\silverback_search\Plugin\search_api\processor\RemoteRenderedItem::getHtml
+   */
+  public function testGetHtml(
+    array $config,
+    $entity,
+    string $expectedResult,
+    ?string $previewUrl,
+    ?array $httpResponses,
+    ?array $expectedError
+  ): void {
+    $item = $this->prophesize(ItemInterface::class);
+    $originalObject = $this->prophesize(\Drupal\Core\TypedData\ComplexDataInterface::class);
+    $originalObject->getValue()->willReturn($entity);
+    $item->getOriginalObject()->willReturn($originalObject->reveal());
+
+    $externalPreviewLink = $this->prophesize(ExternalPreviewLink::class);
+    if ($previewUrl) {
+      $url = $this->prophesize(Url::class);
+      $url->toString()->willReturn($previewUrl);
+      $externalPreviewLink->createPreviewUrlFromEntity($entity, 'live')->willReturn($url->reveal());
+    } else {
+      $externalPreviewLink->createPreviewUrlFromEntity($entity, 'live')->willReturn(null);
+    }
+
+    $httpClient = $this->prophesize(Client::class);
+    if ($httpResponses) {
+      foreach ($httpResponses as $method => $args) {
+        $httpClient->$method(...$args['args'])->willReturn($args['response']);
+      }
+    } else {
+      $httpClient->get(Argument::any())->shouldNotBeCalled();
+      $httpClient->request(Argument::cetera())->shouldNotBeCalled();
+    }
+
+    $logger = $this->prophesize(LoggerInterface::class);
+    if ($expectedError) {
+      $logger->error($expectedError['message'], Argument::any())->shouldBeCalled();
+    } else {
+      $logger->error(Argument::cetera())->shouldNotBeCalled();
+    }
+
+    $processor = new RemoteRenderedItem(
+      $config,
+      'silverback_remote_rendered_item',
+      [],
+      $externalPreviewLink->reveal(),
+      $logger->reveal()
+    );
+
+    $reflection = new \ReflectionClass($processor);
+    $property = $reflection->getProperty('httpClient');
+    $property->setAccessible(true);
+    $property->setValue($processor, $httpClient->reveal());
+
+    $method = $reflection->getMethod('getHtml');
+    $method->setAccessible(true);
+
+    $result = $method->invoke($processor, $item->reveal(), $config);
+    $this->assertEquals($expectedResult, $result);
+  }
+
+  public function getHtmlProvider(): array {
+    $config = [
+      'entity_types' => ['node'],
+      'root_selector' => 'main',
+      'netlify_password' => null,
+    ];
+
+    $contentEntity = $this->prophesize(ContentEntityInterface::class);
+    $contentEntity->getEntityTypeId()->willReturn('node');
+    $contentEntity->id()->willReturn('1');
+
+    $mediaEntity = $this->prophesize(ContentEntityInterface::class);
+    $mediaEntity->getEntityTypeId()->willReturn('media');
+    $mediaEntity->id()->willReturn('1');
+
+    $configWithPassword = [
+      'entity_types' => ['node'],
+      'root_selector' => 'main',
+      'netlify_password' => 'secret123',
+    ];
+
+    $configWithWrongSelector = [
+      'entity_types' => ['node'],
+      'root_selector' => '#nonexistent',
+      'netlify_password' => null,
+    ];
+
+    $previewUrl = 'https://example.com/preview/123';
+    $successHtml = '<html><body><main><h1>Test Content</h1></main></body></html>';
+
+    return [
+      'success_case' => [
+        $config,
+        $contentEntity->reveal(),
+        '<main><h1>Test Content</h1></main>',
+        $previewUrl,
+        [
+          'get' => [
+            'args' => [$previewUrl],
+            'response' => new Response(200, [], $successHtml),
+          ],
+        ],
+        null,
+      ],
+      'non_content_entity' => [
+        $config,
+        new \stdClass(),
+        '',
+        null,
+        null,
+        null,
+      ],
+      'wrong_entity_type' => [
+        $config,
+        $mediaEntity->reveal(),
+        '',
+        null,
+        null,
+        null,
+      ],
+      'no_preview_url' => [
+        $config,
+        $contentEntity->reveal(),
+        '',
+        null,
+        null,
+        null,
+      ],
+      'success_with_401_then_auth' => [
+        $configWithPassword,
+        $contentEntity->reveal(),
+        '<main><h1>Test Content</h1></main>',
+        $previewUrl,
+        [
+          'get' => [
+            'args' => [$previewUrl],
+            'response' => new Response(401),
+          ],
+          'request' => [
+            'args' => [
+              'POST',
+              $previewUrl,
+              [RequestOptions::FORM_PARAMS => ['password' => 'secret123']],
+            ],
+            'response' => new Response(200, [], $successHtml),
+          ],
+        ],
+        null,
+      ],
+      '401_no_password' => [
+        $config,
+        $contentEntity->reveal(),
+        '',
+        $previewUrl,
+        [
+          'get' => [
+            'args' => [$previewUrl],
+            'response' => new Response(401),
+          ],
+        ],
+        [
+          'message' => 'Could not fetch the remote rendered item because Netlify password is not set. Debug:<pre>{debug}</pre>',
+        ],
+      ],
+      '401_wrong_password' => [
+        $configWithPassword,
+        $contentEntity->reveal(),
+        '',
+        $previewUrl,
+        [
+          'get' => [
+            'args' => [$previewUrl],
+            'response' => new Response(401),
+          ],
+          'request' => [
+            'args' => [
+              'POST',
+              $previewUrl,
+              [RequestOptions::FORM_PARAMS => ['password' => 'secret123']],
+            ],
+            'response' => new Response(401),
+          ],
+        ],
+        [
+          'message' => 'Could not fetch the remote rendered item because Netlify password is incorrect. Debug:<pre>{debug}</pre>',
+        ],
+      ],
+      'non_200_response' => [
+        $config,
+        $contentEntity->reveal(),
+        '',
+        $previewUrl,
+        [
+          'get' => [
+            'args' => [$previewUrl],
+            'response' => new Response(500),
+          ],
+        ],
+        [
+          'message' => 'Could not fetch the remote rendered item because the response status code is {status_code}. Debug:<pre>{debug}</pre>',
+        ],
+      ],
+      'selector_not_found' => [
+        $configWithWrongSelector,
+        $contentEntity->reveal(),
+        '',
+        $previewUrl,
+        [
+          'get' => [
+            'args' => [$previewUrl],
+            'response' => new Response(200, [], $successHtml),
+          ],
+        ],
+        [
+          'message' => 'Root selector `{root_selector}` did not match any elements on the page. Debug:<pre>{debug}</pre>',
+        ],
+      ],
+    ];
+  }
+}

--- a/packages/@amazeelabs/silverback-search/drupal/silverback_search/tests/src/Unit/Plugin/search_api/processor/RemoteRenderedItemTest.php
+++ b/packages/@amazeelabs/silverback-search/drupal/silverback_search/tests/src/Unit/Plugin/search_api/processor/RemoteRenderedItemTest.php
@@ -30,11 +30,6 @@ class RemoteRenderedItemTest extends UnitTestCase {
     ?array $httpResponses,
     ?array $expectedError
   ): void {
-    $item = $this->prophesize(ItemInterface::class);
-    $originalObject = $this->prophesize(\Drupal\Core\TypedData\ComplexDataInterface::class);
-    $originalObject->getValue()->willReturn($entity);
-    $item->getOriginalObject()->willReturn($originalObject->reveal());
-
     $externalPreviewLink = $this->prophesize(ExternalPreviewLink::class);
     if ($previewUrl) {
       $url = $this->prophesize(Url::class);
@@ -77,7 +72,7 @@ class RemoteRenderedItemTest extends UnitTestCase {
     $method = $reflection->getMethod('getHtml');
     $method->setAccessible(true);
 
-    $result = $method->invoke($processor, $item->reveal(), $config);
+    $result = $method->invoke($processor, $entity, $config);
     $this->assertEquals($expectedResult, $result);
   }
 
@@ -123,14 +118,6 @@ class RemoteRenderedItemTest extends UnitTestCase {
             'response' => new Response(200, [], $successHtml),
           ],
         ],
-        null,
-      ],
-      'non_content_entity' => [
-        $config,
-        new \stdClass(),
-        '',
-        null,
-        null,
         null,
       ],
       'wrong_entity_type' => [

--- a/packages/@amazeelabs/silverback-search/drupal/silverback_search/tests/src/Unit/Plugin/search_api/processor/RemoteRenderedItemTest.php
+++ b/packages/@amazeelabs/silverback-search/drupal/silverback_search/tests/src/Unit/Plugin/search_api/processor/RemoteRenderedItemTest.php
@@ -2,18 +2,18 @@
 
 namespace Drupal\Tests\silverback_search\Unit\Plugin\search_api\processor;
 
+use Drupal\Core\Database\Connection;
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Url;
-use Drupal\search_api\Item\ItemInterface;
 use Drupal\silverback_external_preview\ExternalPreviewLink;
 use Drupal\silverback_search\Plugin\search_api\processor\RemoteRenderedItem;
 use Drupal\Tests\UnitTestCase;
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\RequestOptions;
-use Psr\Log\LoggerInterface;
-use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Psr\Log\LoggerInterface;
 
 class RemoteRenderedItemTest extends UnitTestCase {
   use ProphecyTrait;
@@ -24,7 +24,7 @@ class RemoteRenderedItemTest extends UnitTestCase {
    */
   public function testGetHtml(
     array $config,
-    $entity,
+    ContentEntityInterface $entity,
     string $expectedResult,
     ?string $previewUrl,
     ?array $httpResponses,
@@ -56,12 +56,15 @@ class RemoteRenderedItemTest extends UnitTestCase {
       $logger->error(Argument::cetera())->shouldNotBeCalled();
     }
 
+    $database = $this->prophesize(Connection::class);
+
     $processor = new RemoteRenderedItem(
       $config,
       'silverback_remote_rendered_item',
       [],
       $externalPreviewLink->reveal(),
-      $logger->reveal()
+      $logger->reveal(),
+      $database->reveal()
     );
 
     $reflection = new \ReflectionClass($processor);
@@ -224,6 +227,177 @@ class RemoteRenderedItemTest extends UnitTestCase {
         [
           'message' => 'Root selector `{root_selector}` did not match any elements on the page. Debug:<pre>{debug}</pre>',
         ],
+      ],
+    ];
+  }
+
+  /**
+   * @dataProvider isOutdatedProvider
+   * @covers \Drupal\silverback_search\Plugin\search_api\processor\RemoteRenderedItem::isOutdated
+   */
+  public function testIsOutdated(
+    bool $expectedResult,
+    ?int $buildId,
+    int $updateCount,
+    string $entityUuid
+  ): void {
+    $externalPreviewLink = $this->prophesize(ExternalPreviewLink::class);
+    $externalPreviewLink->getLiveBaseUrl()->willReturn('https://example.com');
+
+    $httpClient = $this->prophesize(Client::class);
+    if ($buildId !== null) {
+      $httpClient->get('https://example.com/build.json')->willReturn(
+        new Response(200, [], json_encode(['drupalBuildId' => $buildId]))
+      );
+    }
+
+    $logger = $this->prophesize(LoggerInterface::class);
+    $database = $this->prophesize(Connection::class);
+
+    $processor = $this->getMockBuilder(RemoteRenderedItem::class)
+      ->setConstructorArgs([
+        [],
+        'silverback_remote_rendered_item',
+        [],
+        $externalPreviewLink->reveal(),
+        $logger->reveal(),
+        $database->reveal(),
+      ])
+      ->onlyMethods(['getUpdateCount'])
+      ->getMock();
+
+    if ($buildId !== null) {
+      $processor->expects($this->once())
+        ->method('getUpdateCount')
+        ->with($entityUuid, $buildId)
+        ->willReturn($updateCount);
+    } else {
+      $processor->expects($this->never())
+        ->method('getUpdateCount');
+    }
+
+    $reflection = new \ReflectionClass($processor);
+    $property = $reflection->getProperty('httpClient');
+    $property->setAccessible(true);
+    $property->setValue($processor, $httpClient->reveal());
+
+    $method = $reflection->getMethod('isOutdated');
+    $method->setAccessible(true);
+
+    $entity = $this->prophesize(ContentEntityInterface::class);
+    $entity->uuid()->willReturn($entityUuid);
+
+    $result = $method->invoke($processor, $entity->reveal());
+    $this->assertEquals($expectedResult, $result);
+  }
+
+  public function isOutdatedProvider(): array {
+    return [
+      'entity_is_outdated' => [
+        true,
+        100,
+        1,
+        'test-uuid',
+      ],
+      'entity_is_not_outdated' => [
+        false,
+        100,
+        0,
+        'test-uuid',
+      ],
+      'no_build_id' => [
+        false,
+        null,
+        0,
+        'test-uuid',
+      ],
+    ];
+  }
+
+  /**
+   * @dataProvider getBuildIdProvider
+   * @covers \Drupal\silverback_search\Plugin\search_api\processor\RemoteRenderedItem::getBuildId
+   */
+  public function testGetBuildId(
+    ?int $expectedResult,
+    ?Response $response,
+    bool $shouldLogError,
+    ?string $expectedErrorMessage = null
+  ): void {
+    $externalPreviewLink = $this->prophesize(ExternalPreviewLink::class);
+    $externalPreviewLink->getLiveBaseUrl()->willReturn('https://example.com');
+
+    $httpClient = $this->prophesize(Client::class);
+    if ($response) {
+      $httpClient->get('https://example.com/build.json')->willReturn($response);
+    } else {
+      $httpClient->get('https://example.com/build.json')->willThrow(new \Exception('Connection error'));
+    }
+
+    $logger = $this->prophesize(LoggerInterface::class);
+    if ($shouldLogError) {
+      $logger->error($expectedErrorMessage, Argument::any())->shouldBeCalled();
+    } else {
+      $logger->error(Argument::cetera())->shouldNotBeCalled();
+    }
+
+    $database = $this->prophesize(Connection::class);
+
+    $processor = new RemoteRenderedItem(
+      [],
+      'silverback_remote_rendered_item',
+      [],
+      $externalPreviewLink->reveal(),
+      $logger->reveal(),
+      $database->reveal()
+    );
+
+    $reflection = new \ReflectionClass($processor);
+    $property = $reflection->getProperty('httpClient');
+    $property->setAccessible(true);
+    $property->setValue($processor, $httpClient->reveal());
+
+    $method = $reflection->getMethod('getBuildId');
+    $method->setAccessible(true);
+
+    $result = $method->invoke($processor);
+    $this->assertEquals($expectedResult, $result);
+
+    if ($expectedResult !== null) {
+      $cachedResult = $method->invoke($processor);
+      $this->assertEquals($expectedResult, $cachedResult);
+      $httpClient->get('https://example.com/build.json')->shouldHaveBeenCalledOnce();
+    }
+  }
+
+  public function getBuildIdProvider(): array {
+    return [
+      'success_case' => [
+        100,
+        new Response(200, [], json_encode(['drupalBuildId' => 100])),
+        false,
+      ],
+      'non_200_response' => [
+        null,
+        new Response(500),
+        true,
+        'Could not check if the remote rendered item is outdated because the build.json response status code is {status_code}. URL: {url}',
+      ],
+      'missing_build_id' => [
+        null,
+        new Response(200, [], json_encode(['foo' => 'bar'])),
+        false,
+      ],
+      'invalid_build_id' => [
+        null,
+        new Response(200, [], json_encode(['drupalBuildId' => 0])),
+        false,
+      ],
+      'exception_case' => [
+        null,
+        null,
+        true,
+        'Could not fetch build ID: {error}',
       ],
     ];
   }

--- a/packages/@amazeelabs/silverback-search/package.json
+++ b/packages/@amazeelabs/silverback-search/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@amazeelabs/silverback-search",
+  "version": "1.0.0",
+  "scripts": {
+    "test:unit": "cd ../../../apps/cms && vendor/phpunit/phpunit/phpunit web/modules/contrib/silverback_search"
+  }
+}

--- a/packages/@amazeelabs/silverback-search/turbo.json
+++ b/packages/@amazeelabs/silverback-search/turbo.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://turborepo.org/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "test:unit": {
+      "dependsOn": ["@custom/cms#prep:composer"]
+    }
+  }
+}

--- a/packages/drupal/test_content/content/node/696b3f86-fdc7-4c30-900a-24daf08d7e82.yml
+++ b/packages/drupal/test_content/content/node/696b3f86-fdc7-4c30-900a-24daf08d7e82.yml
@@ -1,0 +1,62 @@
+_meta:
+  version: '1.0'
+  entity_type: node
+  uuid: 696b3f86-fdc7-4c30-900a-24daf08d7e82
+  bundle: page
+  default_langcode: en
+default:
+  revision_uid:
+    -
+      target_id: 1
+  status:
+    -
+      value: true
+  uid:
+    -
+      target_id: 1
+  title:
+    -
+      value: 'Remote rendered items test'
+  created:
+    -
+      value: 1742886922
+  promote:
+    -
+      value: false
+  sticky:
+    -
+      value: false
+  moderation_state:
+    -
+      value: published
+  pate_is_template:
+    -
+      value: false
+  pate_structure_only:
+    -
+      value: false
+  path:
+    -
+      alias: /remote-rendered-items-test
+      langcode: en
+      pathauto: 0
+  content_translation_source:
+    -
+      value: und
+  content_translation_outdated:
+    -
+      value: false
+  body:
+    -
+      value: |-
+        <!-- wp:custom/hero /-->
+
+        <!-- wp:custom/content -->
+        <!-- wp:paragraph -->
+        <p>The next paragraph is CTA. All its texts are stored in Gutenberg attributes. The only way to index the link label is to fetch it from the frontend.</p>
+        <!-- /wp:paragraph -->
+
+        <!-- wp:custom/cta {"text":"Trytofindme"} /-->
+        <!-- /wp:custom/content -->
+      format: gutenberg
+      summary: ''

--- a/packages/drupal/test_content/export.php
+++ b/packages/drupal/test_content/export.php
@@ -16,6 +16,7 @@ $excluded = [
   'redirect',
   'webform_submission',
   'consumer',
+  'search_api_task',
 ];
 
 Export::run('test_content', $excluded);

--- a/packages/init/lib.ts
+++ b/packages/init/lib.ts
@@ -81,7 +81,7 @@ export function relinkSharedPackages(sharedPackagesDir: string): void {
       ]) {
         if (targetPkg[depType]) {
           for (const pkg of sharedPackages) {
-            if (targetPkg[depType][pkg.name] === 'workspace:*') {
+            if (targetPkg[depType][pkg.name]?.startsWith('workspace:')) {
               targetPkg[depType][pkg.name] = `^${pkg.version}`;
               updated = true;
             }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,6 +40,9 @@ importers:
       '@amazeelabs/silverback-iframe':
         specifier: workspace:*
         version: link:../../packages/@amazeelabs/silverback-iframe
+      '@amazeelabs/silverback-search':
+        specifier: workspace:^
+        version: link:../../packages/@amazeelabs/silverback-search
       '@custom/custom':
         specifier: workspace:*
         version: link:../../packages/drupal/custom
@@ -408,6 +411,8 @@ importers:
       typescript:
         specifier: ^5.7.3
         version: 5.7.3
+
+  packages/@amazeelabs/silverback-search: {}
 
   packages/drupal/custom: {}
 

--- a/tests/e2e/specs/drupal/silverback-search.spec.ts
+++ b/tests/e2e/specs/drupal/silverback-search.spec.ts
@@ -1,0 +1,61 @@
+import { expect } from '@playwright/test';
+import { execSync } from 'child_process';
+
+import { test } from '../../fixtures';
+import { drush } from '../../helpers/drupal';
+import { cmsUrl } from '../../helpers/url';
+
+test('remote rendered items are indexed', async ({ pageAdmin: page }) => {
+  // Make sure all content is indexed.
+  drush('sapi-c');
+  drush('sapi-i');
+
+  // Check that the content is indexed.
+  await page.goto(cmsUrl('/admin/content'));
+  await page.getByRole('link', { name: 'Go to' }).click();
+  await page.getByRole('textbox', { name: 'Query' }).fill('Trytofindme');
+  await expect(
+    page.getByText('Remote rendered items test (Content)'),
+  ).toBeVisible();
+});
+
+test('remote rendered items are kept dirty until FE build', async ({
+  pageAdmin: page,
+}) => {
+  // We will rebuild the frontend in the test.
+  test.setTimeout(1000 * 60 * 3);
+
+  // Update the CTA link text.
+  await page.goto(cmsUrl('/admin/content'));
+  await page
+    .getByRole('textbox', { name: 'Title' })
+    .fill('Remote rendered items test');
+  await page.getByRole('button', { name: 'Filter' }).click();
+  await page.getByRole('link', { name: 'Edit Remote rendered items' }).click();
+  await page.getByLabel('Link text').fill('Updatedtext');
+  await page.getByText('Save', { exact: true }).click();
+
+  // Re-index content.
+  drush('sapi-i');
+
+  // Check that the updated content is NOT indexed yet. We should be able to
+  // find it by old link text.
+  await page.goto(cmsUrl('/admin/content'));
+  await page.getByRole('link', { name: 'Go to' }).click();
+  await page.getByRole('textbox', { name: 'Query' }).fill('Trytofindme');
+  await expect(
+    page.getByText('Remote rendered items test (Content)'),
+  ).toBeVisible();
+
+  // Re-build frontend and re-index content.
+  execSync(`pnpm run --filter "@custom/website" build`);
+  drush('sapi-i');
+
+  // Check that the updated content is indexed.
+  await page.goto(cmsUrl('/admin/content'));
+  await page.getByRole('link', { name: 'Go to' }).click();
+  await page.getByRole('textbox', { name: 'Query' }).fill('Updatedtext');
+  await expect(
+    page.getByText('Remote rendered items test (Content)'),
+  ).toBeVisible();
+});


### PR DESCRIPTION
## Description of changes

- Introduces `silverback_remote_rendered_item` field for Search API
- Uses this new field instead of `rendered_item` in `global_search` index
- Keeps index items as dirty if the FE is outdated

## Motivation and context

SLB-530 SLB-532

## How has this been tested?

- [x] Manually
- [x] Unit tests
- [x] Integration tests
