### PR TITLE
chore: field group client side validation

### DIFF
--- a/apps/cms/composer.json
+++ b/apps/cms/composer.json
@@ -123,6 +123,9 @@
       },
       "drupal/coffee": {
         "On the fly ajax search POC": "./patches/contrib/coffee/on_the_fly_ajax_search_poc.patch"
+      },
+      "drupal/field_group": {
+        "#2969051 - Fix HTML5 validation prevents submission in tabs": "https://www.drupal.org/files/issues/2024-08-07/field-group-tabs-8.x-3.x.patch"
       }
     },
     "patchLevel": {

--- a/apps/cms/composer.lock
+++ b/apps/cms/composer.lock
@@ -4,7 +4,7 @@
     "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
     "This file is @generated automatically"
   ],
-  "content-hash": "1639922c64f449edb8a4c357475787cc",
+  "content-hash": "0f0b83c1a2cb98823dedebda8411e80b",
   "packages": [
     {
       "name": "amazeeio/drupal_integrations",
@@ -16710,6 +16710,6 @@
   "platform": {
     "php": "^8.3 <8.4"
   },
-  "platform-dev": {},
+  "platform-dev": [],
   "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
## Description of changes

On submit, display the field group that contains a client side validation.

See https://www.drupal.org/project/field_group/issues/2969051

## Motivation and context

Form validation messages are not visible when submitting forms with invalid fields in inactive tabs due to html5 validation.

Note: this patch won't be required anymore when we upgrade to field_group 4.

## How has this been tested?

- [x] Manually
- [ ] Unit tests
- [ ] Integration tests
