### PR TITLE
chore: process media links for custom gutenberg blocks

### DIFF
--- a/packages/drupal/custom/custom.module
+++ b/packages/drupal/custom/custom.module
@@ -10,12 +10,7 @@ use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Language\LanguageInterface;
 use Drupal\Core\Render\Element;
-use Drupal\Core\Render\RenderContext;
-use Drupal\Core\StreamWrapper\LocalStream;
-use Drupal\Core\StreamWrapper\StreamWrapperInterface;
-use Drupal\Core\Utility\Error as ErrorUtil;
 use Drupal\file\Entity\File;
-use Drupal\media\Entity\Media;
 use Drupal\node\NodeInterface;
 use Drupal\silverback_gutenberg\LinkProcessor;
 use Drupal\user\Entity\Role;
@@ -58,45 +53,9 @@ function custom_silverback_gutenberg_link_processor_outbound_url_alter(
   LanguageInterface $language,
   LinkProcessor $linkProcessor,
 ) {
-
-  // For some links pointing to media, we want to print the direct file URL
-  // instead of the media route.
-  if (preg_match('#^(/[a-z]{2})?/media/([0-9]+)(/edit)?$#', $url, $matches)) {
-    $mediaBundles = ['document'];
-    \Drupal::service('renderer')->executeInRenderContext(
-      new RenderContext(),
-      function () use (&$url, $matches, $language, $mediaBundles) {
-        $mediaId = $matches[2];
-        try {
-          /** @var \Drupal\media\MediaInterface $media */
-          $media = Media::load($mediaId);
-          if (
-            $language->getId() !== $media->language()->getId() &&
-            $media->hasTranslation($language->getId())
-          ) {
-            $media = $media->getTranslation($language->getId());
-          }
-          if (
-            in_array($media->bundle(), $mediaBundles) &&
-            $media->access('view')
-          ) {
-            $source = $media->getSource()->getSourceFieldValue($media);
-            $file = File::load($source);
-            $url = $file->createFileUrl();
-          }
-        }
-        catch (\Throwable $e) {
-          \Drupal::logger('custom')->error(
-            'Error turning media (id: "{mediaId}") route into file url. Error: {error}',
-            [
-              'mediaId' => $mediaId,
-              'error' => ErrorUtil::renderExceptionSafe($e),
-            ]
-                  );
-        }
-      }
-    );
-  }
+  /** @var \Drupal\custom\MediaLinks $mediaLinks */
+  $mediaLinks = \Drupal::service('custom.media_links');
+  $url = $mediaLinks->getMediaFileUrl($url, $language);
 }
 
 /**
@@ -114,60 +73,9 @@ function custom_silverback_gutenberg_link_processor_inbound_link_alter(
   \DOMElement $link,
   LinkProcessor $linkProcessor,
 ) {
-  // For inbound links (when data gets saved), if the link points to a public
-  // file, then we want to replace the href value with "media/uuid/edit" and
-  // also make sure the data-id and data-entity-type attributes have the proper
-  // values (the uuid and the 'media' value). This is a special case for media,
-  // because the url of the media item is replaced by
-  // custom_silverback_gutenberg_link_processor_outbound_url_alter() with the
-  // file path, so now on inbound we need to basically do the opposite. This is
-  // needed so that the entity usage integration works properly (where the
-  // data-id and data-entity-type attributes are checked).
-  $href = $link->getAttribute('href');
-  /** @var \Drupal\Core\StreamWrapper\StreamWrapperManager $wrapperManager */
-  $wrapperManager = \Drupal::service('stream_wrapper_manager');
-  /** @var \Drupal\Core\StreamWrapper\StreamWrapperInterface[] $visibleWrappers */
-  $visibleWrappers = $wrapperManager->getWrappers(StreamWrapperInterface::VISIBLE);
-  foreach ($visibleWrappers as $scheme => $wrapperInfo) {
-    $wrapper = $wrapperManager->getViaScheme($scheme);
-    // We are only handle local streams for now.
-    if (!$wrapper instanceof LocalStream) {
-      continue;
-    }
-    if (!str_starts_with($href, '/' . $wrapper->getDirectoryPath() . '/')) {
-      continue;
-    }
-    // When searching for a file inside the database, the wrapper uri is used
-    // instead of the directory path. That is why we need the wrapper in the
-    // first place.
-    $fileuri = str_replace('/' . $wrapper->getDirectoryPath() . '/', $wrapper->getUri(), urldecode($href));
-    $files = \Drupal::entityTypeManager()
-      ->getStorage('file')
-      ->loadByProperties(['uri' => $fileuri]);
-    // No files found, just continue to the next wrapper.
-    if (empty($files)) {
-      continue;
-    }
-    $file = array_shift($files);
-    $usageList = \Drupal::service('file.usage')->listUsage($file);
-    // If the media file usage list is empty, then this is probably some kind of
-    // orphan file, or tracked by some other entity type.
-    if (empty($usageList['file']['media'])) {
-      continue;
-    }
-    $mids = array_keys($usageList['file']['media']);
-    $mid = reset($mids);
-    $media = Media::load($mid);
-    if (empty($media)) {
-      continue;
-    }
-    // If we got here, we found a matching media item, so we can populate the
-    // link metadata with its values and just break out of the wrappers loop.
-    $link->setAttribute('href', '/media/' . $media->uuid() . '/edit');
-    $link->setAttribute('data-id', $media->uuid());
-    $link->setAttribute('data-entity-type', 'media');
-    break;
-  }
+  /** @var \Drupal\custom\MediaLinks $mediaLinks */
+  $mediaLinks = \Drupal::service('custom.media_links');
+  $mediaLinks->processInboundLink($link);
 }
 
 /**

--- a/packages/drupal/custom/custom.services.yml
+++ b/packages/drupal/custom/custom.services.yml
@@ -21,3 +21,7 @@ services:
     class: Drupal\custom\EventSubscriber\RobotsSubscriber
     tags:
       - { name: event_subscriber }
+
+  custom.media_links:
+    class: Drupal\custom\MediaLinks
+    arguments: ['@renderer', '@logger.factory', '@stream_wrapper_manager', '@file.usage']

--- a/packages/drupal/custom/custom.services.yml
+++ b/packages/drupal/custom/custom.services.yml
@@ -24,4 +24,5 @@ services:
 
   custom.media_links:
     class: Drupal\custom\MediaLinks
-    arguments: ['@renderer', '@logger.factory', '@stream_wrapper_manager', '@file.usage']
+    arguments:
+      ['@renderer', '@logger.factory', '@stream_wrapper_manager', '@file.usage']

--- a/packages/drupal/custom/src/MediaLinks.php
+++ b/packages/drupal/custom/src/MediaLinks.php
@@ -40,7 +40,7 @@ final class MediaLinks {
    * @return string
    */
   public function getMediaFileUrl(
-    string &$url,
+    string $url,
     LanguageInterface $language,
     array $media_bundles = ['document']
   ): string {

--- a/packages/drupal/custom/src/MediaLinks.php
+++ b/packages/drupal/custom/src/MediaLinks.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\custom;
+
+use Drupal\Core\Language\LanguageInterface;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Core\Render\RenderContext;
+use Drupal\Core\Render\RendererInterface;
+use Drupal\Core\StreamWrapper\LocalStream;
+use Drupal\Core\StreamWrapper\StreamWrapperInterface;
+use Drupal\Core\StreamWrapper\StreamWrapperManagerInterface;
+use Drupal\Core\Utility\Error as ErrorUtil;
+use Drupal\file\Entity\File;
+use Drupal\file\FileUsage\DatabaseFileUsageBackend;
+use Drupal\media\Entity\Media;
+
+final class MediaLinks {
+
+  /**
+   * Constructs a MediaLinks object.
+   */
+  public function __construct(
+    private readonly RendererInterface $renderer,
+    private readonly LoggerChannelFactoryInterface $loggerFactory,
+    private readonly StreamWrapperManagerInterface $streamWrapperManager,
+    private readonly DatabaseFileUsageBackend $fileUsage,
+  ) {}
+
+  /**
+   * For some links pointing to Media, we want to print the direct file URL
+   * instead of the media route.
+   *
+   * @param string $url
+   *
+   * @return string
+   */
+  public function getMediaFileUrl(string &$url, LanguageInterface $language, array $media_bundles = ['document']): string {
+    if (preg_match('#^(/[a-z]{2})?/media/([0-9]+)(/edit)?$#', $url, $matches)) {
+      $this->renderer->executeInRenderContext(
+        new RenderContext(),
+        function () use (&$url, $matches, $language, $media_bundles) {
+          $mediaId = $matches[2];
+          try {
+            /** @var \Drupal\media\MediaInterface $media */
+            $media = Media::load($mediaId);
+            if (
+              $language->getId() !== $media->language()->getId() &&
+              $media->hasTranslation($language->getId())
+            ) {
+              $media = $media->getTranslation($language->getId());
+            }
+            if (
+              in_array($media->bundle(), $media_bundles) &&
+              $media->access('view')
+            ) {
+              $source = $media->getSource()->getSourceFieldValue($media);
+              $file = File::load($source);
+              $url = $file->createFileUrl();
+            }
+          }
+          catch (\Throwable $e) {
+            $this->loggerFactory->get('custom')->error(
+              'Error turning media (id: "{mediaId}") route into file url. Error: {error}',
+              [
+                'mediaId' => $mediaId,
+                'error' => ErrorUtil::renderExceptionSafe($e),
+              ]
+            );
+          }
+        }
+      );
+    }
+
+    return $url;
+  }
+
+  /**
+   * Processes inbound links altered by outbound_url_alter() / useMediaFileUrl().
+   *
+   * For inbound links (when data gets saved), if the link points to a public
+   * file, then we want to replace the href value with "media/uuid/edit" and
+   * also make sure the data-id and data-entity-type attributes have the proper
+   * values (the uuid and the 'media' value). This is a special case for media,
+   * because the url of the media item is replaced by
+   * custom_silverback_gutenberg_link_processor_outbound_url_alter() with the
+   * file path, so now on inbound we need to basically do the opposite. This is
+   * needed so that the entity usage integration works properly (where the
+   * data-id and data-entity-type attributes are checked).
+   *
+   * @param \DOMElement $link
+   *
+   * @return void
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   */
+  public function processInboundLink(\DOMElement $link): void {
+    $href = $link->getAttribute('href');
+    /** @var \Drupal\Core\StreamWrapper\StreamWrapperInterface[] $visibleWrappers */
+    $visibleWrappers = $this->streamWrapperManager->getWrappers(StreamWrapperInterface::VISIBLE);
+    foreach ($visibleWrappers as $scheme => $wrapperInfo) {
+      $wrapper = $this->streamWrapperManager->getViaScheme($scheme);
+      // We are only handling local streams for now.
+      if (!$wrapper instanceof LocalStream) {
+        continue;
+      }
+      if (!str_starts_with($href, '/' . $wrapper->getDirectoryPath() . '/')) {
+        continue;
+      }
+      // When searching for a file inside the database, the wrapper uri is used
+      // instead of the directory path. That is why we need the wrapper in the
+      // first place.
+      $fileUri = str_replace('/' . $wrapper->getDirectoryPath() . '/', $wrapper->getUri(), urldecode($href));
+      $files = \Drupal::entityTypeManager()
+        ->getStorage('file')
+        ->loadByProperties(['uri' => $fileUri]);
+      // No files found, just continue to the next wrapper.
+      if (empty($files)) {
+        continue;
+      }
+      $file = array_shift($files);
+      $usageList = $this->fileUsage->listUsage($file);
+      // If the media file usage list is empty, then this is probably some kind of
+      // orphan file, or tracked by some other entity type.
+      if (empty($usageList['file']['media'])) {
+        continue;
+      }
+      $mediaIds = array_keys($usageList['file']['media']);
+      $mediaId = reset($mediaIds);
+      $media = Media::load($mediaId);
+      if (empty($media)) {
+        continue;
+      }
+      // If we got here, we found a matching media item, so we can populate the
+      // link metadata with its values and just break out of the wrappers loop.
+      $link->setAttribute('href', '/media/' . $media->uuid() . '/edit');
+      $link->setAttribute('data-id', $media->uuid());
+      $link->setAttribute('data-entity-type', 'media');
+      break;
+    }
+  }
+
+}

--- a/packages/drupal/custom/src/MediaLinks.php
+++ b/packages/drupal/custom/src/MediaLinks.php
@@ -29,14 +29,21 @@ final class MediaLinks {
   ) {}
 
   /**
-   * For some links pointing to Media, we want to print the direct file URL
-   * instead of the media route.
+   * Returns a File url based on the parent Media path.
    *
    * @param string $url
-   *
+   *   The Media relative url.
+   * @param \Drupal\Core\Language\LanguageInterface $language
+   *   The language of the Media translation to use.
+   * @param array $media_bundles
+   *   An array of allowed media bundles.
    * @return string
    */
-  public function getMediaFileUrl(string &$url, LanguageInterface $language, array $media_bundles = ['document']): string {
+  public function getMediaFileUrl(
+    string &$url,
+    LanguageInterface $language,
+    array $media_bundles = ['document']
+  ): string {
     if (preg_match('#^(/[a-z]{2})?/media/([0-9]+)(/edit)?$#', $url, $matches)) {
       $this->renderer->executeInRenderContext(
         new RenderContext(),

--- a/packages/drupal/gutenberg_blocks/gutenberg_blocks.info.yml
+++ b/packages/drupal/gutenberg_blocks/gutenberg_blocks.info.yml
@@ -6,3 +6,4 @@ core_version_requirement: ^9 || ^10
 dependencies:
   - gutenberg:gutenberg
   - silverback_gutenberg:silverback_gutenberg
+  - custom:custom

--- a/packages/drupal/gutenberg_blocks/gutenberg_blocks.module
+++ b/packages/drupal/gutenberg_blocks/gutenberg_blocks.module
@@ -117,3 +117,21 @@ function _template_preprocess_gutenberg_block_add_rendered_image(&$variables) {
     );
   }
 }
+
+/**
+ * Implements hook_silverback_gutenberg_link_processor_block_attrs_alter().
+ */
+function gutenberg_blocks_silverback_gutenberg_link_processor_block_attrs_alter(array &$attributes, array $context) {
+  // The CTA block can contain the url to a Media,
+  // so we need to transform it into a link to the actual File.
+  // @see custom_silverback_gutenberg_link_processor_outbound_url_alter().
+  if ($context['blockName'] === 'custom/cta' && !empty($attributes['url'])) {
+    /** @var \Drupal\custom\MediaLinks $mediaLinks */
+    $mediaLinks = \Drupal::service('custom.media_links');
+    $language = \Drupal::languageManager()->getDefaultLanguage();
+    if (!empty($context['language']) && $context['language'] instanceof LanguageInterface) {
+      $language = $context['language'];
+    }
+    $attributes['url'] = $mediaLinks->getMediaFileUrl($attributes['url'], $language);
+  }
+}


### PR DESCRIPTION
## Description of changes

- Refactor `custom_silverback_gutenberg_link_processor_outbound_url_alter()` and `custom_silverback_gutenberg_link_processor_inbound_link_alter()` as a `MediaLinks` service
- Implement an example for the custom Gutenberg `cta` block

## Motivation and context

We want the same behaviour as `custom_silverback_gutenberg_link_processor_outbound_url_alter()` and be able to easily extend to other blocks.

**Before**

<img width="381" alt="Screenshot 2025-03-31 at 15 45 18" src="https://github.com/user-attachments/assets/67419f48-4858-4b06-8748-5e0d8cbf8019" />

<img width="487" alt="Screenshot 2025-03-31 at 15 44 53" src="https://github.com/user-attachments/assets/e7be6e23-9b09-437e-9808-80495bab6027" />

---

**After**

<img width="378" alt="Screenshot 2025-03-31 at 16 10 58" src="https://github.com/user-attachments/assets/c01b87f7-4bff-49f6-9cb9-a4b5ce342029" />

<img width="520" alt="Screenshot 2025-03-31 at 16 11 26" src="https://github.com/user-attachments/assets/e5f75939-4e23-4532-88fc-54857fce6f2f" />

## How has this been tested?

- [x] Manually
- [ ] Unit tests
- [ ] Integration tests
