### PR TITLE
fix: add lang context to hero block

### DIFF
--- a/packages/schema/src/schema.graphql
+++ b/packages/schema/src/schema.graphql
@@ -228,7 +228,7 @@ type DrupalPage implements Page & Editable & CardItem
     @resolveEditorBlocks(path: "body.value")
     @seek(pos: 0)
     @resolveEditorBlockMedia
-  hero: Hero @resolveEditorBlocks(path: "body.value") @seek(pos: 0)
+  hero: Hero @lang @resolveEditorBlocks(path: "body.value") @seek(pos: 0)
   content: [PageContent]
     @lang
     @resolveEditorBlocks(


### PR DESCRIPTION
Otherwise, the webform url might be rendered in a wrong language.