### PR TITLE
feat(SLB-542): resolve entity language path if url.prefixes is configured

### DIFF
--- a/apps/cms/composer.json
+++ b/apps/cms/composer.json
@@ -122,9 +122,6 @@
       "drupal/graphql": {
         "Check if translation exists when loading an entity by its uuid": "./patches/graphql_load_by_uuid_translation_check.patch"
       },
-      "drupal/graphql_directives": {
-        "#3524387 Resolve entity language path if url.prefixes is configured": "https://git.drupalcode.org/project/graphql_directives/-/merge_requests/1.patch"
-      },
       "drupal/coffee": {
         "On the fly ajax search POC": "./patches/contrib/coffee/on_the_fly_ajax_search_poc.patch"
       },

--- a/apps/cms/composer.json
+++ b/apps/cms/composer.json
@@ -122,6 +122,9 @@
       "drupal/graphql": {
         "Check if translation exists when loading an entity by its uuid": "./patches/graphql_load_by_uuid_translation_check.patch"
       },
+      "drupal/graphql_directives": {
+        "#3524387 Resolve entity language path if url.prefixes is configured": "https://git.drupalcode.org/project/graphql_directives/-/merge_requests/1.patch"
+      },
       "drupal/coffee": {
         "On the fly ajax search POC": "./patches/contrib/coffee/on_the_fly_ajax_search_poc.patch"
       },

--- a/apps/cms/composer.lock
+++ b/apps/cms/composer.lock
@@ -3596,7 +3596,7 @@
       "source": {
         "type": "git",
         "url": "https://git.drupalcode.org/project/graphql_directives.git",
-        "reference": "b3ff1a8696c091f4e3a9a76fe28b68e434f52530"
+        "reference": "e637be1d3bb7a21c3aef0f2f7517c61e17bbb9f6"
       },
       "require": {
         "drupal/core": "^8.8 || ^9 || ^10 || ^11",
@@ -3613,7 +3613,7 @@
         },
         "drupal": {
           "version": "1.0.x-dev",
-          "datestamp": "1745651525",
+          "datestamp": "1747315204",
           "security-coverage": {
             "status": "not-covered",
             "message": "Project has not opted into security advisory coverage!"
@@ -3625,6 +3625,10 @@
         "GPL-2.0+"
       ],
       "authors": [
+        {
+          "name": "colorfield",
+          "homepage": "https://www.drupal.org/user/2295486"
+        },
         {
           "name": "pmelab",
           "homepage": "https://www.drupal.org/user/555322"

--- a/apps/cms/composer.lock
+++ b/apps/cms/composer.lock
@@ -4,7 +4,7 @@
     "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
     "This file is @generated automatically"
   ],
-  "content-hash": "efc9aaffcc72cf539686debcf9ecfb76",
+  "content-hash": "3c1e220dfb05f0b55f738f977ee205af",
   "packages": [
     {
       "name": "amazeeio/drupal_integrations",

--- a/apps/cms/composer.lock
+++ b/apps/cms/composer.lock
@@ -4,7 +4,7 @@
     "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
     "This file is @generated automatically"
   ],
-  "content-hash": "3c1e220dfb05f0b55f738f977ee205af",
+  "content-hash": "efc9aaffcc72cf539686debcf9ecfb76",
   "packages": [
     {
       "name": "amazeeio/drupal_integrations",

--- a/apps/cms/config/sync/language.entity.de.yml
+++ b/apps/cms/config/sync/language.entity.de.yml
@@ -5,5 +5,5 @@ dependencies: {  }
 id: de
 label: German
 direction: ltr
-weight: 1
+weight: -9
 locked: false

--- a/apps/cms/config/sync/language.entity.en.yml
+++ b/apps/cms/config/sync/language.entity.en.yml
@@ -7,5 +7,5 @@ _core:
 id: en
 label: English
 direction: ltr
-weight: 0
+weight: -10
 locked: false

--- a/apps/cms/config/sync/language.entity.fr.yml
+++ b/apps/cms/config/sync/language.entity.fr.yml
@@ -5,5 +5,5 @@ dependencies: {  }
 id: fr
 label: French
 direction: ltr
-weight: 2
+weight: -7
 locked: false

--- a/apps/cms/config/sync/language.entity.fr.yml
+++ b/apps/cms/config/sync/language.entity.fr.yml
@@ -1,0 +1,9 @@
+uuid: 2872c1e0-544c-49c5-8488-3ebcd432c2e4
+langcode: en
+status: true
+dependencies: {  }
+id: fr
+label: French
+direction: ltr
+weight: 2
+locked: false

--- a/apps/cms/config/sync/language.entity.gsw-berne.yml
+++ b/apps/cms/config/sync/language.entity.gsw-berne.yml
@@ -1,0 +1,9 @@
+uuid: c924dbf4-0223-4d86-8d5a-03649ecccff8
+langcode: en
+status: true
+dependencies: {  }
+id: gsw-berne
+label: 'Swiss German'
+direction: ltr
+weight: -8
+locked: false

--- a/apps/cms/config/sync/language.entity.und.yml
+++ b/apps/cms/config/sync/language.entity.und.yml
@@ -7,5 +7,5 @@ _core:
 id: und
 label: 'Not specified'
 direction: ltr
-weight: 2
+weight: 3
 locked: true

--- a/apps/cms/config/sync/language.entity.und.yml
+++ b/apps/cms/config/sync/language.entity.und.yml
@@ -7,5 +7,5 @@ _core:
 id: und
 label: 'Not specified'
 direction: ltr
-weight: 3
+weight: 4
 locked: true

--- a/apps/cms/config/sync/language.entity.zxx.yml
+++ b/apps/cms/config/sync/language.entity.zxx.yml
@@ -7,5 +7,5 @@ _core:
 id: zxx
 label: 'Not applicable'
 direction: ltr
-weight: 3
+weight: 4
 locked: true

--- a/apps/cms/config/sync/language.entity.zxx.yml
+++ b/apps/cms/config/sync/language.entity.zxx.yml
@@ -7,5 +7,5 @@ _core:
 id: zxx
 label: 'Not applicable'
 direction: ltr
-weight: 4
+weight: 5
 locked: true

--- a/apps/cms/config/sync/language.negotiation.yml
+++ b/apps/cms/config/sync/language.negotiation.yml
@@ -7,9 +7,11 @@ url:
   prefixes:
     en: en
     de: de
+    gsw-berne: de-CH
     fr: french
   domains:
     en: ''
     de: ''
+    gsw-berne: ''
     fr: ''
 selected_langcode: site_default

--- a/apps/cms/config/sync/language.negotiation.yml
+++ b/apps/cms/config/sync/language.negotiation.yml
@@ -7,8 +7,9 @@ url:
   prefixes:
     en: en
     de: de
-    '': null
+    fr: french
   domains:
     en: ''
     de: ''
+    fr: ''
 selected_langcode: site_default

--- a/apps/cms/gatsby-node.mjs
+++ b/apps/cms/gatsby-node.mjs
@@ -23,7 +23,7 @@ export const createPages = async ({ actions }) => {
   // Create the content hub page in each language.
   Object.values(Locale).forEach((locale) => {
     actions.createPage({
-      path: `/${locale}/content-hub`,
+      path: `/${formatLocalePath(locale)}/content-hub`,
       component: resolve(`./src/templates/content-hub.tsx`),
     });
   });
@@ -65,3 +65,13 @@ export const createPages = async ({ actions }) => {
     });
   });
 };
+
+/**
+ * Format locale containing the country code,
+ * so it's ISO 639-1 compliant in the path.
+ * This is needed as GraphQL enums are not supporting dashes (-).
+ * @param {string} locale
+ */
+function formatLocalePath(locale) {
+  return locale.replace('_', '-');
+}

--- a/apps/website/gatsby-node.mjs
+++ b/apps/website/gatsby-node.mjs
@@ -51,14 +51,14 @@ export const createPages = async ({ actions }) => {
   // Create pages and root-redirects for home-pages.
   homePages.forEach((page) => {
     actions.createPage({
-      path: `/${page.locale}`,
+      path: `/${formatLocalePath(page.locale)}`,
       component: resolve('./src/templates/home.tsx'),
     });
     // If a menu link points to the drupal-path of a home page,
     // it should redirect to the root path with the language prefix.
     actions.createRedirect({
       fromPath: page.path,
-      toPath: `/${page.locale}`,
+      toPath: `/${formatLocalePath(page.locale)}`,
       statusCode: 301,
     });
   });
@@ -88,7 +88,7 @@ export const createPages = async ({ actions }) => {
   // Create the content hub page in each language.
   Object.values(Locale).forEach((locale) => {
     actions.createPage({
-      path: `/${locale}/content-hub`,
+      path: `/${formatLocalePath(locale)}/content-hub`,
       component: resolve(`./src/templates/content-hub.tsx`),
     });
   });
@@ -96,7 +96,7 @@ export const createPages = async ({ actions }) => {
   // Create a inquiry page in each language.
   Object.values(Locale).forEach((locale) => {
     actions.createPage({
-      path: `/${locale}/inquiry`,
+      path: `/${formatLocalePath(locale)}/inquiry`,
       component: resolve(`./src/templates/inquiry.tsx`),
     });
   });
@@ -165,4 +165,14 @@ function removeIndentation(str) {
     .map((line) => line.slice(minIndent))
     .join('\n')
     .trim();
+}
+
+/**
+ * Format locale containing the country code,
+ * so it's ISO 639-1 compliant in the path.
+ * This is needed as GraphQL enums are not supporting dashes (-).
+ * @param {string} locale
+ */
+function formatLocalePath(locale) {
+  return locale.replace('_', '-');
 }

--- a/apps/website/src/utils/locale.ts
+++ b/apps/website/src/utils/locale.ts
@@ -14,7 +14,8 @@ export function isLocale(input: any): input is Locale {
  */
 export function useLocale() {
   const [{ pathname }] = useLocation();
-  const prefix = pathname.split('/')[1];
+  // GraphQL enums are not supporting dashes (-).
+  const prefix = pathname.split('/')[1].replace('-', '_');
   return isLocale(prefix) ? prefix : defaultLocale;
 }
 

--- a/packages/drupal/test_content/content/menu_link_content/ea4b851d-5af5-4bb3-bf95-a7d10531ff10.yml
+++ b/packages/drupal/test_content/content/menu_link_content/ea4b851d-5af5-4bb3-bf95-a7d10531ff10.yml
@@ -68,3 +68,41 @@ translations:
     content_translation_created:
       -
         value: 1680856832
+  gsw-berne:
+    title:
+      -
+        value: Privacy
+    content_translation_source:
+      -
+        value: und
+    content_translation_outdated:
+      -
+        value: false
+    content_translation_uid:
+      -
+        target_id: 1
+    content_translation_status:
+      -
+        value: true
+    content_translation_created:
+      -
+        value: 1680856832
+  fr:
+    title:
+      -
+        value: Privacy
+    content_translation_source:
+      -
+        value: und
+    content_translation_outdated:
+      -
+        value: false
+    content_translation_uid:
+      -
+        target_id: 1
+    content_translation_status:
+      -
+        value: true
+    content_translation_created:
+      -
+        value: 1680856832

--- a/packages/drupal/test_content/content/node/50a28359-32f7-48ee-9577-330d79a2b62c.yml
+++ b/packages/drupal/test_content/content/node/50a28359-32f7-48ee-9577-330d79a2b62c.yml
@@ -109,3 +109,93 @@ translations:
           <!-- /wp:custom/content -->
         format: gutenberg
         summary: ''
+  gsw-berne:
+    status:
+      -
+        value: true
+    uid:
+      -
+        target_id: 1
+    title:
+      -
+        value: Privatsphäre
+    created:
+      -
+        value: 1747072844
+    promote:
+      -
+        value: false
+    sticky:
+      -
+        value: false
+    moderation_state:
+      -
+        value: published
+    path:
+      -
+        alias: /privacy
+        langcode: gsw-berne
+        pathauto: 0
+    content_translation_source:
+      -
+        value: en
+    content_translation_outdated:
+      -
+        value: false
+    body:
+      -
+        value: |-
+          <!-- wp:custom/hero {"headline":"Privatsph\u00e4re","lead":"FADP"} /-->
+
+          <!-- wp:custom/content -->
+          <!-- wp:paragraph -->
+          <p></p>
+          <!-- /wp:paragraph -->
+          <!-- /wp:custom/content -->
+        format: gutenberg
+        summary: ''
+  fr:
+    status:
+      -
+        value: true
+    uid:
+      -
+        target_id: 1
+    title:
+      -
+        value: 'Vie privée'
+    created:
+      -
+        value: 1747070384
+    promote:
+      -
+        value: false
+    sticky:
+      -
+        value: false
+    moderation_state:
+      -
+        value: published
+    path:
+      -
+        alias: /privacy
+        langcode: fr
+        pathauto: 0
+    content_translation_source:
+      -
+        value: en
+    content_translation_outdated:
+      -
+        value: false
+    body:
+      -
+        value: |-
+          <!-- wp:custom/hero {"headline":"Vie priv\u00e9e","lead":"... ou son absence."} /-->
+
+          <!-- wp:custom/content -->
+          <!-- wp:paragraph -->
+          <p></p>
+          <!-- /wp:paragraph -->
+          <!-- /wp:custom/content -->
+        format: gutenberg
+        summary: ''

--- a/packages/schema/src/schema.graphql
+++ b/packages/schema/src/schema.graphql
@@ -79,6 +79,7 @@ directive @route(
 enum Locale @default @value(string: "en") {
   en
   de
+  gsw_berne
   fr
 }
 

--- a/packages/schema/src/schema.graphql
+++ b/packages/schema/src/schema.graphql
@@ -77,10 +77,10 @@ directive @route(
 ) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 enum Locale @default @value(string: "en") {
-  de
   en
-  fr
-  gsw_berne
+  de
+  de_CH
+  french
 }
 
 enum Backend @default @value(string: "drupal") {

--- a/packages/schema/src/schema.graphql
+++ b/packages/schema/src/schema.graphql
@@ -77,10 +77,10 @@ directive @route(
 ) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 enum Locale @default @value(string: "en") {
-  en
   de
-  gsw_berne
+  en
   fr
+  gsw_berne
 }
 
 enum Backend @default @value(string: "drupal") {

--- a/packages/schema/src/schema.graphql
+++ b/packages/schema/src/schema.graphql
@@ -79,6 +79,7 @@ directive @route(
 enum Locale @default @value(string: "en") {
   en
   de
+  fr
 }
 
 enum Backend @default @value(string: "drupal") {

--- a/packages/ui/src/components/Molecules/LanguageSwitcher.stories.tsx
+++ b/packages/ui/src/components/Molecules/LanguageSwitcher.stories.tsx
@@ -21,6 +21,7 @@ const TranslationsDecorator = ((Story, ctx) => {
                 translations: [
                   { locale: 'en', path: '/en/home' as Url },
                   { locale: 'de', path: '/de/home' as Url },
+                  { locale: 'fr', path: '/french/home' as Url },
                 ],
               },
             },
@@ -59,6 +60,7 @@ export const Full = {
   args: {
     de: '/de/german-version' as Url,
     en: '/en/english-version' as Url,
+    fr: '/french/french-version' as Url,
   },
 } satisfies Story;
 
@@ -66,6 +68,7 @@ export const Homepage = {
   args: {
     de: '/de/home' as Url,
     en: '/en/home' as Url,
+    fr: '/french/home' as Url,
   },
   parameters: {
     location: new URL('local:/de'),

--- a/packages/ui/src/components/Molecules/LanguageSwitcher.stories.tsx
+++ b/packages/ui/src/components/Molecules/LanguageSwitcher.stories.tsx
@@ -25,6 +25,7 @@ const TranslationsDecorator = ((Story, ctx) => {
               homePage: {
                 translations: [
                   { locale: Locale.En, path: '/en/home' as Url },
+                  { locale: Locale.GswBerne, path: '/de-CH/home' as Url },
                   { locale: Locale.De, path: '/de/home' as Url },
                   { locale: Locale.Fr, path: '/french/home' as Url },
                 ],
@@ -64,6 +65,7 @@ export const Partial = {
 export const Full = {
   args: {
     de: '/de/german-version' as Url,
+    gsw_berne: '/de-CH/swiss-german-version' as Url,
     en: '/en/english-version' as Url,
     fr: '/french/french-version' as Url,
   },
@@ -72,6 +74,7 @@ export const Full = {
 export const Homepage = {
   args: {
     de: '/de/home' as Url,
+    gsw_berne: '/de-CH/home' as Url,
     en: '/en/home' as Url,
     fr: '/french/home' as Url,
   },

--- a/packages/ui/src/components/Molecules/LanguageSwitcher.stories.tsx
+++ b/packages/ui/src/components/Molecules/LanguageSwitcher.stories.tsx
@@ -1,7 +1,7 @@
 import {
   FrameQuery,
-  OperationExecutorsProvider,
   Locale,
+  OperationExecutorsProvider,
   Url,
 } from '@custom/schema';
 import { Decorator, Meta, StoryObj } from '@storybook/react';

--- a/packages/ui/src/components/Molecules/LanguageSwitcher.stories.tsx
+++ b/packages/ui/src/components/Molecules/LanguageSwitcher.stories.tsx
@@ -1,4 +1,9 @@
-import { FrameQuery, OperationExecutorsProvider, Url } from '@custom/schema';
+import {
+  FrameQuery,
+  OperationExecutorsProvider,
+  Locale,
+  Url,
+} from '@custom/schema';
 import { Decorator, Meta, StoryObj } from '@storybook/react';
 import React from 'react';
 
@@ -19,9 +24,9 @@ const TranslationsDecorator = ((Story, ctx) => {
             websiteSettings: {
               homePage: {
                 translations: [
-                  { locale: 'en', path: '/en/home' as Url },
-                  { locale: 'de', path: '/de/home' as Url },
-                  { locale: 'fr', path: '/french/home' as Url },
+                  { locale: Locale.En, path: '/en/home' as Url },
+                  { locale: Locale.De, path: '/de/home' as Url },
+                  { locale: Locale.Fr, path: '/french/home' as Url },
                 ],
               },
             },

--- a/packages/ui/src/components/Molecules/LanguageSwitcher.stories.tsx
+++ b/packages/ui/src/components/Molecules/LanguageSwitcher.stories.tsx
@@ -25,9 +25,9 @@ const TranslationsDecorator = ((Story, ctx) => {
               homePage: {
                 translations: [
                   { locale: Locale.En, path: '/en/home' as Url },
-                  { locale: Locale.GswBerne, path: '/de-CH/home' as Url },
                   { locale: Locale.De, path: '/de/home' as Url },
-                  { locale: Locale.Fr, path: '/french/home' as Url },
+                  { locale: Locale.DeCh, path: '/de-CH/home' as Url },
+                  { locale: Locale.French, path: '/french/home' as Url },
                 ],
               },
             },
@@ -64,19 +64,19 @@ export const Partial = {
 
 export const Full = {
   args: {
-    de: '/de/german-version' as Url,
-    gsw_berne: '/de-CH/swiss-german-version' as Url,
     en: '/en/english-version' as Url,
-    fr: '/french/french-version' as Url,
+    de: '/de/german-version' as Url,
+    de_CH: '/de-CH/swiss-german-version' as Url,
+    french: '/french/french-version' as Url,
   },
 } satisfies Story;
 
 export const Homepage = {
   args: {
-    de: '/de/home' as Url,
-    gsw_berne: '/de-CH/home' as Url,
     en: '/en/home' as Url,
-    fr: '/french/home' as Url,
+    de: '/de/home' as Url,
+    de_CH: '/de-CH/home' as Url,
+    french: '/french/home' as Url,
   },
   parameters: {
     location: new URL('local:/de'),

--- a/packages/ui/src/components/Molecules/LanguageSwitcher.stories.tsx
+++ b/packages/ui/src/components/Molecules/LanguageSwitcher.stories.tsx
@@ -41,6 +41,7 @@ export default {
   decorators: [TranslationsDecorator],
   parameters: {
     location: new URL('local:/en/english-version'),
+    layout: 'centered',
   },
 } satisfies Meta<TranslationPaths>;
 

--- a/packages/ui/src/components/Molecules/LanguageSwitcher.tsx
+++ b/packages/ui/src/components/Molecules/LanguageSwitcher.tsx
@@ -14,10 +14,22 @@ import React, { Fragment } from 'react';
 import { useTranslations } from '../../utils/translations';
 
 function getLanguageName(locale: string) {
-  const languageNames = new Intl.DisplayNames([locale], {
+  const formattedLocale = formatLocalePath(locale);
+  const languageNames = new Intl.DisplayNames([formattedLocale], {
     type: 'language',
   });
-  return languageNames.of(locale);
+  return languageNames.of(formattedLocale);
+}
+
+/**
+ * Format locale containing the country code,
+ * so it's ISO 639-1 compliant in the path.
+ * This is needed as GraphQL enums are not supporting dashes (-).
+ *
+ * @param locale
+ */
+function formatLocalePath(locale: Locale | string) {
+  return locale.replace('_', '-');
 }
 
 export function LanguageSwitcher() {

--- a/packages/ui/src/components/Molecules/PageTransition.tsx
+++ b/packages/ui/src/components/Molecules/PageTransition.tsx
@@ -77,12 +77,12 @@ function getLanguageMessage(url: string): ReactNode {
             'Diese Seite ist nicht in der angeforderten Sprache verfügbar.',
           goBack: 'Zurück',
         },
-        gsw_berne: {
+        de_CH: {
           message:
             'Diese Seite ist nicht in der angeforderten Sprache verfügbar.',
           goBack: 'Zurück',
         },
-        fr: {
+        french: {
           message: "Cette page n'est pas disponible dans la langue demandée",
           goBack: 'Retour',
         },

--- a/packages/ui/src/components/Molecules/PageTransition.tsx
+++ b/packages/ui/src/components/Molecules/PageTransition.tsx
@@ -77,6 +77,10 @@ function getLanguageMessage(url: string): ReactNode {
             'Diese Seite ist nicht in der angeforderten Sprache verfügbar.',
           goBack: 'Zurück',
         },
+        fr: {
+          message: "Cette page n'est pas disponible dans la langue demandée",
+          goBack: 'Retour',
+        },
       };
       const translation = translations[requestedLanguage as Locale];
       if (translation) {

--- a/packages/ui/src/components/Molecules/PageTransition.tsx
+++ b/packages/ui/src/components/Molecules/PageTransition.tsx
@@ -77,6 +77,11 @@ function getLanguageMessage(url: string): ReactNode {
             'Diese Seite ist nicht in der angeforderten Sprache verfügbar.',
           goBack: 'Zurück',
         },
+        gsw_berne: {
+          message:
+            'Diese Seite ist nicht in der angeforderten Sprache verfügbar.',
+          goBack: 'Zurück',
+        },
         fr: {
           message: "Cette page n'est pas disponible dans la langue demandée",
           goBack: 'Retour',

--- a/tests/e2e/specs/drupal/content-editing.spec.ts
+++ b/tests/e2e/specs/drupal/content-editing.spec.ts
@@ -35,7 +35,7 @@ test.describe('content-editing', () => {
     await page.getByText('Save', { exact: true }).click();
     await page.getByRole('link', { name: 'Translate' }).click();
     const translateUrl = page.url();
-    await page.getByRole('link', { name: 'Add', exact: true }).click();
+    await page.getByRole('link', { name: 'Add', exact: true }).first().click();
     await page.locator("[name='title[0][value]']").fill('A draft translation');
     await page.getByLabel('Ändern in').selectOption('draft');
     await page.getByLabel('Headline').fill('A draft translation');

--- a/tests/schema/specs/menu.spec.ts
+++ b/tests/schema/specs/menu.spec.ts
@@ -45,6 +45,14 @@ test('Meta', async () => {
             ],
             "locale": "de",
           },
+          {
+            "items": [],
+            "locale": "de_CH",
+          },
+          {
+            "items": [],
+            "locale": "french",
+          },
         ],
       },
     }

--- a/tests/schema/specs/translation.spec.ts
+++ b/tests/schema/specs/translation.spec.ts
@@ -1,0 +1,147 @@
+import gql from 'noop-tag';
+import { expect, test } from 'vitest';
+
+import { fetch } from '../lib.js';
+
+test('Page', async () => {
+  const result = await fetch(gql`
+    fragment Page on Page {
+      locale
+      path
+      title
+      translations {
+        locale
+        path
+        title
+      }
+    }
+    {
+      loadFromEnglishPath: viewPage(path: "/en/privacy") {
+        ...Page
+      }
+      loadFromGermanPath: viewPage(path: "/de/privatsphaere") {
+        ...Page
+      }
+      loadFromSwissGermanPath: viewPage(path: "/de-CH/privacy") {
+        ...Page
+      }
+      loadFromFrenchPath: viewPage(path: "/french/privacy") {
+        ...Page
+      }
+    }
+  `);
+  expect(result).toMatchInlineSnapshot(`
+    {
+      "data": {
+        "loadFromEnglishPath": {
+          "locale": "en",
+          "path": "/en/privacy",
+          "title": "Privacy",
+          "translations": [
+            {
+              "locale": "en",
+              "path": "/en/privacy",
+              "title": "Privacy",
+            },
+            {
+              "locale": "de",
+              "path": "/de/privatsphaere",
+              "title": "Privatsphäre",
+            },
+            {
+              "locale": "de_CH",
+              "path": "/de-CH/privacy",
+              "title": "Privatsphäre",
+            },
+            {
+              "locale": "french",
+              "path": "/french/privacy",
+              "title": "Vie privée",
+            },
+          ],
+        },
+        "loadFromFrenchPath": {
+          "locale": "french",
+          "path": "/french/privacy",
+          "title": "Vie privée",
+          "translations": [
+            {
+              "locale": "en",
+              "path": "/en/privacy",
+              "title": "Privacy",
+            },
+            {
+              "locale": "de",
+              "path": "/de/privatsphaere",
+              "title": "Privatsphäre",
+            },
+            {
+              "locale": "de_CH",
+              "path": "/de-CH/privacy",
+              "title": "Privatsphäre",
+            },
+            {
+              "locale": "french",
+              "path": "/french/privacy",
+              "title": "Vie privée",
+            },
+          ],
+        },
+        "loadFromGermanPath": {
+          "locale": "de",
+          "path": "/de/privatsphaere",
+          "title": "Privatsphäre",
+          "translations": [
+            {
+              "locale": "en",
+              "path": "/en/privacy",
+              "title": "Privacy",
+            },
+            {
+              "locale": "de",
+              "path": "/de/privatsphaere",
+              "title": "Privatsphäre",
+            },
+            {
+              "locale": "de_CH",
+              "path": "/de-CH/privacy",
+              "title": "Privatsphäre",
+            },
+            {
+              "locale": "french",
+              "path": "/french/privacy",
+              "title": "Vie privée",
+            },
+          ],
+        },
+        "loadFromSwissGermanPath": {
+          "locale": "de_CH",
+          "path": "/de-CH/privacy",
+          "title": "Privatsphäre",
+          "translations": [
+            {
+              "locale": "en",
+              "path": "/en/privacy",
+              "title": "Privacy",
+            },
+            {
+              "locale": "de",
+              "path": "/de/privatsphaere",
+              "title": "Privatsphäre",
+            },
+            {
+              "locale": "de_CH",
+              "path": "/de-CH/privacy",
+              "title": "Privatsphäre",
+            },
+            {
+              "locale": "french",
+              "path": "/french/privacy",
+              "title": "Vie privée",
+            },
+          ],
+        },
+      },
+    }
+  `);
+});


### PR DESCRIPTION
## Description of changes

- Configure 2 new languages: French `fr` with path set as `french` and Swiss German `gsw-berne` with path set as `de-CH`
- Add locales to the schema and frontend
- Adjust the frontend to format GraphQL enums to the expected language path

Once reviewed, we can update the `graphql_directives` module and remove the temporary MR patch from https://git.drupalcode.org/project/graphql_directives/-/merge_requests/1

## Motivation and context

See https://www.drupal.org/project/graphql_directives/issues/3524387

## How has this been tested?

- [x] Manually
- [ ] Unit tests
- [x] Integration tests
