### PR TITLE
Per-Project lagoon vector database

### DIFF
--- a/.lagoon/pgvector/Dockerfile
+++ b/.lagoon/pgvector/Dockerfile
@@ -1,0 +1,14 @@
+# Instead of using pgvector/pgvector:pg15 image, we use Lagoon's Postgres image
+# (since it has lots of Lagoon related stuff), and install pgvector manually.
+FROM uselagoon/postgres-15
+
+# Recepie from https://stackoverflow.com/a/79466221/580371
+WORKDIR /app
+RUN apk add git build-base clang19 llvm19-dev
+RUN git clone --branch v0.8.0 --depth 1 https://github.com/pgvector/pgvector.git
+WORKDIR /app/pgvector
+RUN make
+RUN make install
+
+# Init script.
+COPY .lagoon/pgvector/init.sql /docker-entrypoint-initdb.d/01_pgvector.sql

--- a/.lagoon/pgvector/init.sql
+++ b/.lagoon/pgvector/init.sql
@@ -1,0 +1,13 @@
+-- Enable the pgvector extension so we can store vector embeddings
+CREATE EXTENSION IF NOT EXISTS vector;
+
+-- Create the table that Search API will use for storing embeddings
+CREATE TABLE IF NOT EXISTS search_api_vector (
+  id BIGSERIAL PRIMARY KEY,
+  content VARCHAR,
+  drupal_entity_id VARCHAR,
+  drupal_long_id VARCHAR,
+  server_id VARCHAR,
+  index_id VARCHAR,
+  embedding vector(1024)
+);

--- a/apps/cms/composer.json
+++ b/apps/cms/composer.json
@@ -130,6 +130,9 @@
       "drupal/coffee": {
         "On the fly ajax search POC": "./patches/contrib/coffee/on_the_fly_ajax_search_poc.patch"
       },
+      "drupal/ai_vdb_provider_postgres": {
+        "Fix query": "./patches/contrib/ai_vdb_provider_postgres/fix-query.patch"
+      },
       "drupal/field_group": {
         "#2969051 - Fix HTML5 validation prevents submission in tabs": "https://www.drupal.org/files/issues/2024-08-07/field-group-tabs-8.x-3.x.patch"
       }

--- a/apps/cms/config/sync/key.key.pgvector_password_key.yml
+++ b/apps/cms/config/sync/key.key.pgvector_password_key.yml
@@ -1,0 +1,14 @@
+uuid: 8ba1439d-1fb8-4736-863e-a042b83c87c0
+langcode: en
+status: true
+dependencies: {  }
+id: pgvector_password_key
+label: 'pgvector password'
+description: 'Password for the pgvector database'
+key_type: authentication
+key_type_settings: {  }
+key_provider: config
+key_provider_settings:
+  key_value: lagoon
+key_input: text_field
+key_input_settings: {  }

--- a/apps/cms/config/sync/search_api.index.drupal_content.yml
+++ b/apps/cms/config/sync/search_api.index.drupal_content.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
-    - search_api.server.amazee_ai
+    - search_api.server.pgvector
   module:
     - node
     - silverback_search
@@ -64,4 +64,4 @@ options:
   delete_on_fail: true
   index_directly: true
   track_changes_in_references: true
-server: amazee_ai
+server: pgvector

--- a/apps/cms/config/sync/search_api.server.pgvector.yml
+++ b/apps/cms/config/sync/search_api.server.pgvector.yml
@@ -1,0 +1,27 @@
+uuid: 2775961e-fc26-415b-ad5f-e34538ded3fe
+langcode: en
+status: true
+dependencies:
+  module:
+    - ai_search
+id: pgvector
+name: 'Postgres with pgvector'
+description: ''
+backend: search_api_ai_search
+backend_config:
+  chat_model: amazeeio__claude-3-5-sonnet
+  database: postgres
+  database_settings:
+    database_name: lagoon
+    collection: search_api_vector
+    metric: cosine_similarity
+  embeddings_engine: 'amazeeio__titan-embed-text-v2:0'
+  embeddings_engine_configuration:
+    set_dimensions: false
+    dimensions: 1024
+  embedding_strategy: contextual_chunks
+  embedding_strategy_configuration:
+    chunk_size: '500'
+    chunk_min_overlap: '100'
+    contextual_content_max_percentage: '30'
+  embedding_strategy_details: ''

--- a/apps/cms/patches/contrib/ai_vdb_provider_postgres/fix-query.patch
+++ b/apps/cms/patches/contrib/ai_vdb_provider_postgres/fix-query.patch
@@ -1,0 +1,22 @@
+diff --git a/src/PostgresPgvectorClient.php b/src/PostgresPgvectorClient.php
+index 08ec3db..aafab4f 100644
+--- a/src/PostgresPgvectorClient.php
++++ b/src/PostgresPgvectorClient.php
+@@ -313,7 +313,7 @@ class PostgresPgvectorClient {
+     if (empty($filters)) {
+       // CosineSimilarity requires a special query.
+       if ($metric_type === VdbSimilarityMetrics::CosineSimilarity) {
+-        $query = "SELECT (1-real_distance) as distance, {$outfield_fields} FROM (SELECT embedding {$metric_name} {$vectors} as real_distance, {$prepared_output_fields} FROM {$escaped_collection_name}) ORDER BY distance DESC LIMIT {$limit} OFFSET {$offset};";
++        $query = "SELECT (1-real_distance) as distance, {$outfield_fields} FROM (SELECT embedding {$metric_name} {$vectors} as real_distance, {$prepared_output_fields} FROM {$escaped_collection_name}) AS sub ORDER BY distance DESC LIMIT {$limit} OFFSET {$offset};";
+       }
+       else {
+         $query = "SELECT embedding {$metric_name} {$vectors} as distance, {$prepared_output_fields} FROM {$escaped_collection_name} ORDER BY distance LIMIT {$limit} OFFSET {$offset};";
+@@ -321,7 +321,7 @@ class PostgresPgvectorClient {
+     }
+     else {
+       if ($metric_type === VdbSimilarityMetrics::CosineSimilarity) {
+-        $query = "SELECT (1-real_distance) as distance, {$outfield_fields} FROM (SELECT embedding {$metric_name} {$vectors} as real_distance, {$prepared_output_fields} FROM {$escaped_collection_name} {$filters}) ORDER BY distance DESC LIMIT {$limit} OFFSET {$offset};";
++        $query = "SELECT (1-real_distance) as distance, {$outfield_fields} FROM (SELECT embedding {$metric_name} {$vectors} as real_distance, {$prepared_output_fields} FROM {$escaped_collection_name} {$filters}) AS sub ORDER BY distance DESC LIMIT {$limit} OFFSET {$offset};";
+       }
+       else {
+         $query = "SELECT embedding {$metric_name} {$vectors} as distance, {$prepared_output_fields} FROM {$escaped_collection_name} {$filters} ORDER BY distance LIMIT {$limit} OFFSET {$offset};";

--- a/apps/cms/scaffold/settings.php.append.txt
+++ b/apps/cms/scaffold/settings.php.append.txt
@@ -79,3 +79,9 @@ if (file_exists(__DIR__ . '/services.local.yml')) {
 }
 
 $config['silverback_ai.settings']['open_ai_api_key'] = getenv('OPEN_AI_API_KEY');
+
+$config['ai_vdb_provider_postgres.settings']['host'] = 'pgvector';
+$config['ai_vdb_provider_postgres.settings']['port'] = 5432;
+$config['ai_vdb_provider_postgres.settings']['username'] = 'lagoon';
+$config['ai_vdb_provider_postgres.settings']['password'] = 'pgvector_password_key';
+$config['ai_vdb_provider_postgres.settings']['default_database'] = 'lagoon';

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,8 @@ version: '2.3'
 x-volumes:
   &default-volumes # Define all volumes you would like to have real-time mounted into the docker containers
   volumes:
-    - ./packages/drupal:/app/web/modules/custom:delegated
+    # This makes all symlinks work: Drupal modules/themes, local packages in node_modules.
+    - ./packages:/packages:delegated
     - ./apps/cms:/app:delegated
 
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ x-volumes:
 
 volumes:
   chat-storage:
+  db:
 
 x-environment: &default-environment
   LAGOON_PROJECT: &lagoon-project ${COMPOSE_PROJECT_NAME:-slbtemplate}
@@ -93,6 +94,19 @@ services:
     <<: *default-user # uses the defined user from top
     environment:
       <<: *default-environment
+
+  pgvector:
+    build:
+      context: .
+      dockerfile: .lagoon/pgvector/Dockerfile
+    labels:
+      lagoon.type: postgres
+    ports:
+      - '5432'
+    environment:
+      <<: *default-environment
+    volumes:
+      - db:/var/lib/postgresql/data
 
   build:
     build:


### PR DESCRIPTION
## Motivation and context

ALGMTB-67

> The lagoon-chat environment of the silverback-template project right now uses an external vector database provided by amazee.ai. For management and scalability reasons, it should rather have a dedicated container.

## How has this been tested?

- [x] Manually (in Docker locally)
- [ ] Unit tests
- [ ] Integration tests

<details>
<summary>Locally it worked</summary>

![Screenshot_2025-05-21_at_17_40_59](https://github.com/user-attachments/assets/5363d986-128d-478d-b772-13d02e2eee4e)

</details>

---

The general test failure is unrelated - coming from the base branch.

---

Deployment might need several Drupal config import attempts. There can be errors, but they are gone just by re-running `drush cim` few times.