### PR TITLE
fix: avoid circular references in path processor

### DIFF
--- a/packages/@amazeelabs/silverback-iframe/drupal/silverback_iframe/silverback_iframe.module
+++ b/packages/@amazeelabs/silverback-iframe/drupal/silverback_iframe/silverback_iframe.module
@@ -9,11 +9,11 @@ function silverback_iframe_inject_resizer() {
   if (!getenv('SB_ENVIRONMENT')) {
     return FALSE;
   }
-  return \Drupal::request()->query->get('iframe_resizer') === 'true';
+  return ($_GET['iframe_resizer'] ?? '') === 'true';
 }
 
 function silverback_iframe_theme_enabled() {
-  return \Drupal::request()->get('iframe') === 'true';
+  return ($_GET['iframe'] ?? '') === 'true';
 }
 
 /**

--- a/packages/@amazeelabs/silverback-iframe/drupal/silverback_iframe/silverback_iframe.module
+++ b/packages/@amazeelabs/silverback-iframe/drupal/silverback_iframe/silverback_iframe.module
@@ -9,10 +9,12 @@ function silverback_iframe_inject_resizer() {
   if (!getenv('SB_ENVIRONMENT')) {
     return FALSE;
   }
+  // Using $_GET directly to prevent possible service circular dependency errors.
   return ($_GET['iframe_resizer'] ?? '') === 'true';
 }
 
 function silverback_iframe_theme_enabled() {
+  // Using $_GET directly to prevent possible service circular dependency errors.
   return ($_GET['iframe'] ?? '') === 'true';
 }
 


### PR DESCRIPTION
## Motivation and context

Getting this on other project:
```
Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException:
Circular reference detected for service "domain.route_provider",
path: "options_request_listener -> domain.route_provider -> path_processor_manager -> silverback_iframe.path_processor -> maintenance_mode_subscriber -> url_generator".
in Drupal\Component\DependencyInjection\Container->get()
(line 149 of core/lib/Drupal/Component/DependencyInjection/Container.php).
```

**UPD**: The error was caused by a different issue 😅 Yet, the changes from PR do not hurt 😁

## How has this been tested?

- [ ] Manually
- [ ] Unit tests
- [x] Integration tests
