### PR TITLE
feat: add claude code hooks for automated precommit

### DIFF
--- a/.claude/precommit-hook.sh
+++ b/.claude/precommit-hook.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+# Claude Hook Script for Precommit
+# Automatically runs precommit in the package directory containing the edited file
+
+set -e
+
+# Function to find the nearest package.json file
+find_package_root() {
+    local dir="$1"
+    while [[ "$dir" != "/" ]]; do
+        if [[ -f "$dir/package.json" ]]; then
+            echo "$dir"
+            return 0
+        fi
+        dir="$(dirname "$dir")"
+    done
+    return 1
+}
+
+# Function to output JSON response
+output_json() {
+    local success="$1"
+    local message="$2"
+    local output="$3"
+    
+    cat << EOF
+{
+    "success": $success,
+    "message": "$message",
+    "output": "$output"
+}
+EOF
+}
+
+# Check if file path is provided
+if [[ $# -eq 0 ]]; then
+    output_json false "No file path provided" ""
+    exit 1
+fi
+
+FILE_PATH="$1"
+ABSOLUTE_PATH=$(realpath "$FILE_PATH" 2>/dev/null || echo "$FILE_PATH")
+
+# Find the package root
+PACKAGE_ROOT=$(find_package_root "$(dirname "$ABSOLUTE_PATH")")
+
+if [[ -z "$PACKAGE_ROOT" ]]; then
+    output_json false "No package.json found in directory tree" ""
+    exit 1
+fi
+
+# Check if package.json has precommit script
+if ! grep -q '"precommit"' "$PACKAGE_ROOT/package.json"; then
+    output_json true "No precommit script found in package.json, skipping" ""
+    exit 0
+fi
+
+# Change to package directory and run precommit
+cd "$PACKAGE_ROOT"
+
+# Capture output and exit code
+PRECOMMIT_OUTPUT=$(pnpm precommit 2>&1)
+EXIT_CODE=$?
+
+if [[ $EXIT_CODE -eq 0 ]]; then
+    output_json true "Precommit passed successfully" "$PRECOMMIT_OUTPUT"
+else
+    # Escape output for JSON
+    ESCAPED_OUTPUT=$(echo "$PRECOMMIT_OUTPUT" | sed 's/"/\\"/g' | sed 's/\\/\\\\/g' | tr '\n' '\\n')
+    output_json false "Precommit failed" "$ESCAPED_OUTPUT"
+    exit 1
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,32 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(pnpm:*)",
+      "Bash(npm:*)",
+      "Bash(git:*)",
+      "Bash(composer:*)",
+      "Bash(drush:*)",
+      "Bash(playwright:*)",
+      "Bash(vitest:*)",
+      "Bash(eslint:*)",
+      "Bash(tsc:*)",
+      "Bash(phpcs:*)",
+      "Bash(phpstan:*)",
+      "Bash(phpunit:*)"
+    ]
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/precommit-hook.sh \"$CLAUDE_TOOL_FILE_PATH\"",
+            "output": "json"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,7 +12,16 @@
       "Bash(tsc:*)",
       "Bash(phpcs:*)",
       "Bash(phpstan:*)",
-      "Bash(phpunit:*)"
+      "Bash(phpunit:*)",
+      "mcp__playwright__browser_navigate",
+      "mcp__playwright__browser_type",
+      "mcp__playwright__browser_click",
+      "mcp__playwright__browser_select_option",
+      "mcp__playwright__browser_snapshot",
+      "mcp__playwright__browser_resize",
+      "mcp__playwright__browser_close",
+      "mcp__figma__get_code",
+      "mcp__figma__get_image"
     ]
   },
   "hooks": {

--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,4 @@ apps/website/.env
 /_local
 /lerna-debug.log
 /.prettierignore
-.claude/
+.claude/settings.local.json

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,14 @@
+{
+  "mcpServers": {
+    "playwright": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["@playwright/mcp@latest", "--headless"],
+      "env": {}
+    },
+    "figma": {
+      "type": "sse",
+      "url": "http://127.0.0.1:3845/sse"
+    }
+  }
+}

--- a/.prettierignore-append
+++ b/.prettierignore-append
@@ -3,3 +3,4 @@ pnpm-lock.yaml
 .idea
 CLAUDE.md
 .claude
+CHANGELOG.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,23 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Quick Start for Claude Code
+
+### Essential Commands (Run These First)
+- `pnpm i && pnpm turbo:prep` - Initial setup after branch switch
+- `pnpm precommit` - Fix formatting, run linters, and execute unit tests  
+- `pnpm turbo:test` - Full test suite (unit + integration)
+- `pnpm turbo:test:integration` - Integration tests only
+
+### Development URLs
+- Drupal backend: `http://localhost:8888` (admin/admin)
+- Gatsby frontend: `http://localhost:8000`
+
+### Testing Commands
+- E2E tests: `cd tests/e2e && playwright test`
+- Interactive E2E: `cd tests/e2e && playwright test --ui`
+- Unit tests: `pnpm turbo:test:unit`
+
 ## Project Architecture
 
 **Silverback Template** - A sophisticated monorepo for building headless CMS applications using Drupal and Gatsby.
@@ -29,52 +46,29 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `/packages/@amazeelabs/` - Amazee Labs specific packages, published to NPM.js. Only available in `silverback-template`, not in derived projects.
 - `/packages/eslint-config/` - Shared ESLint configuration
 
-## Essential Commands
+## Claude Code Workflow Integration
 
-### Initial Setup
-```bash
-pnpm i && pnpm turbo:prep
-```
+### Branch Strategy & Git Workflow
+- **Main branch**: `release` (create PRs against this)
+- **Environments**: `prod` (production), `dev` (testing), `stage` (staging)
+- **Feature branches**: `lagoon-*` (get dedicated environments)
 
-### Pre-commit Quality Checks
-```bash
-pnpm precommit             # Fix formatting, run linters, and execute unit tests
-```
-
-### Testing
-```bash
-pnpm turbo:test             # Full test suite (unit + integration)
-pnpm turbo:test:integration # Integration tests only
-```
-
-## Testing Framework
-
-### E2E Testing (Playwright)
-```bash
-cd tests/e2e
-playwright test          # Headless
-playwright test --headed # With browser UI
-playwright test --ui     # Interactive mode
-```
+### Development Workflow
+1. Create branch from `release`
+2. Create PR against `release`
+3. Merge to `dev` for testing
+4. After approval, merge to `release`
+5. Deploy to production by merging `release` to `prod`
 
 ### Test Locations
 - `/tests/e2e-basic/` - Simple smoke tests
 - `/tests/e2e/` - Comprehensive integration tests
 - `/tests/schema/` - GraphQL schema validation
 
-## Branch Strategy
-- `release` - Production-ready code (no environment)
-- `prod` - Production environment
-- `dev` - Main development/testing environment
-- `stage` - Secondary staging environment
-- `lagoon-*` - Feature branches with dedicated environments
-
-## Development Workflow
-1. Create branch from `release`
-2. Create PR against `release`
-3. Merge to `dev` for testing
-4. After approval, merge to `release`
-5. Deploy to production by merging `release` to `prod`
+### Quality Assurance Commands
+- **Before committing**: `pnpm precommit`
+- **Before PR**: `pnpm turbo:test`
+- **Schema changes**: `pnpm prep` (in `packages/schema`)
 
 ## Key Architectural Patterns
 
@@ -116,47 +110,54 @@ The build follows stages: prep → test:static → test:unit → test:integratio
 
 ## Development Best Practices
 
-- If a task requires new operations or data structures, start by adjusting the GraphQL schema and operations.
-- Run `pnpm precommit` after code changes, which will fix formatting and run linters and unit tests.
-- Always run `pnpm install && pnpm turbo:prep` after switching branches to avoid issues
+### General Development
+- **GraphQL-first**: Start with schema/operations for new features
+- **Quality checks**: Run `pnpm precommit` after code changes
+- **Branch switching**: Run `pnpm install && pnpm turbo:prep` after switching branches
+- **Dependencies**: Check package.json for existing libraries before adding new ones
+- **No index files**: Don't create `index.ts` files that aggregate directories
 
-### Storybook and UI Component Development
-- Create Storybook stories for UI components. Cover input property edge cases and create play functions for testing interactions.
-- Visible interface strings have to be translated using 'react-intl'.
-- Never use string concatenation for class attributes, always use 'clsx'.
-- Implement frontend business logic in Typescript utilities that are tested with vitest.
-- Avoid using useEffect and useContext in React. Try to solve the problem with zustand instead.
-- Test zustand stores with vitest by accessing them directly, not through React hooks.
-- **Never attempt to start storybook. It should already be running in the background.**
-- Make sure to use `intl.formatMessage` in react for any text in the user interface. Don't concatenate strings with variables, but use the variables feature of `intl.formatMessage`.
-- Never use string templates for react classNames. Build dynamic classNames with clsx.
+### React & Frontend Development
+- **State management**: Use zustand instead of useEffect/useContext
+- **Testing**: Test zustand stores directly with vitest (not through React hooks)
+- **Styling**: Use clsx for dynamic classNames, never string concatenation
+- **Internationalization**: Use `intl.formatMessage` for all UI text
+- **Storybook**: Create stories for UI components with play functions
+- **Storybook note**: Never start storybook - it runs in background
+- **Business logic**: Implement in TypeScript utilities with vitest tests
 
-### Drupal Extensions
-- Create services for Drupal business logic and create PHPUnit tests for them.
-- Create Kernel tests for interconnected Drupal services. Avoid mocking services, unless they connect to external systems.
-- Keep Drupal hooks as simple as possible. If they get complex, they should instead call a unit-tested service.
+### Drupal Development
+- **Services**: Create PHPUnit-tested services for business logic
+- **Hooks**: Keep simple, delegate complex logic to services
+- **Testing**: Use Kernel tests for interconnected services
+- **Configuration**: Use web UI + `drush cex -y` (never write config files)
+- **Content**: Use web UI + `pnpm content:export` (never add content manually)
 
 ### GraphQL Schema
-- Avoid technical Details, keep types and fields technology agnostic and readable to humans.
-- Add GraphQL block comments for describing schema elements. Use markdown for clarity.
-- Run `pnpm prep` in `packages/schema` after changing the schema, operations or fragments to verify correctness.
+- **Human-readable**: Keep types/fields technology-agnostic
+- **Documentation**: Add GraphQL block comments with markdown
+- **Validation**: Run `pnpm prep` in `packages/schema` after changes
 
-## Styling and UI Configurations
+## File & Asset Management
 
-### CSS and Styling Techniques
-- Content of `SilverbackIframe` is styled in @packages/ui/src/iframe.css , by applying tailwind classes to Drupal classes using `@apply`.
+### Styling
+- **Iframe styling**: `packages/ui/src/iframe.css` uses `@apply` for Drupal classes
+- **Assets**: Download from Figma → `packages/ui/static/public/` (available at "/" in browser)
 
-## Asset Management
+### Important Configuration Files
+- `/phpcs.xml.dist` - PHP CodeSniffer configuration
+- `/phpstan.neon` - PHPStan static analysis
+- `/packages/eslint-config/` - Shared ESLint configuration
+- `turbo.json` - Turborepo build pipeline configuration
 
-- Always download assets from figma and put them into the `packages/ui/static/public` directory, which is available at the "/" level in the browser.
+## Environment & Production Setup
 
-## Drupal Configuration Management
+### Required Environment Variables
+- `DRUPAL_HASH_SALT` - Security salt (required)
+- `NETLIFY_SITE_ID`, `NETLIFY_AUTH_TOKEN` - Netlify deployment
+- `CLOUDINARY_*` - Image processing
+- `DRUPAL_INTERNAL_URL`, `DRUPAL_EXTERNAL_URL` - Service URLs
+- `PUBLISHER_OAUTH2_CLIENT_SECRET` - OAuth2 authentication
 
-- Never write Drupal configuration **anywhere**. Use the browser to log into `http://localhost:8888` using username `admin` and password `admin`, do the configuration changes using the web interface and then persist them by running `drush cex -y` in the `apps/cms` folder.
-
-## Drupal Test Content Management
-
-- Never add Drupal test content manually. Use the browser to log into `http://localhost:8888` using username `admin` and password `admin`, do the cotnent changes using the web interface and then persist them by running `pnpm content:export` in the `apps/cms` folder.
-
-## Testing Best Practices
-- Schema tests should use inline snapshots and test concrete values as much as possible.
+### Build Pipeline
+Turborepo stages: `prep → test:static → test:unit → test:integration`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,8 +39,6 @@ pnpm i && pnpm turbo:prep
 ### Pre-commit Quality Checks
 ```bash
 pnpm precommit             # Fix formatting, run linters, and execute unit tests
-pnpm precommit:fix         # Only auto-fix formatting and linting issues
-pnpm precommit:check       # Only validate without fixing
 ```
 
 ### Testing
@@ -129,6 +127,9 @@ The build follows stages: prep → test:static → test:unit → test:integratio
 - Implement frontend business logic in Typescript utilities that are tested with vitest.
 - Avoid using useEffect and useContext in React. Try to solve the problem with zustand instead.
 - Test zustand stores with vitest by accessing them directly, not through React hooks.
+- **Never attempt to start storybook. It should already be running in the background.**
+- Make sure to use `intl.formatMessage` in react for any text in the user interface. Don't concatenate strings with variables, but use the variables feature of `intl.formatMessage`.
+- Never use string templates for react classNames. Build dynamic classNames with clsx.
 
 ### Drupal Extensions
 - Create services for Drupal business logic and create PHPUnit tests for them.
@@ -144,3 +145,18 @@ The build follows stages: prep → test:static → test:unit → test:integratio
 
 ### CSS and Styling Techniques
 - Content of `SilverbackIframe` is styled in @packages/ui/src/iframe.css , by applying tailwind classes to Drupal classes using `@apply`.
+
+## Asset Management
+
+- Always download assets from figma and put them into the `packages/ui/static/public` directory, which is available at the "/" level in the browser.
+
+## Drupal Configuration Management
+
+- Never write Drupal configuration **anywhere**. Use the browser to log into `http://localhost:8888` using username `admin` and password `admin`, do the configuration changes using the web interface and then persist them by running `drush cex -y` in the `apps/cms` folder.
+
+## Drupal Test Content Management
+
+- Never add Drupal test content manually. Use the browser to log into `http://localhost:8888` using username `admin` and password `admin`, do the cotnent changes using the web interface and then persist them by running `pnpm content:export` in the `apps/cms` folder.
+
+## Testing Best Practices
+- Schema tests should use inline snapshots and test concrete values as much as possible.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,3 +139,8 @@ The build follows stages: prep → test:static → test:unit → test:integratio
 - Avoid technical Details, keep types and fields technology agnostic and readable to humans.
 - Add GraphQL block comments for describing schema elements. Use markdown for clarity.
 - Run `pnpm prep` in `packages/schema` after changing the schema, operations or fragments to verify correctness.
+
+## Styling and UI Configurations
+
+### CSS and Styling Techniques
+- Content of `SilverbackIframe` is styled in @packages/ui/src/iframe.css , by applying tailwind classes to Drupal classes using `@apply`.


### PR DESCRIPTION
## Summary
• Added Claude Code hooks configuration for automated precommit validation
• Created precommit hook script that runs in package directories containing edited files
• Updated .gitignore to allow .claude/ directory while excluding local settings
• Added default MCP configuration with Playwright and Figma support

## Test plan
- [ ] Verify precommit hook runs when editing files in packages with precommit script
- [ ] Test that hook gracefully handles packages without precommit script
- [ ] Confirm MCP integration works with Playwright and Figma
- [ ] Validate that .claude/settings.local.json is properly ignored

🤖 Generated with [Claude Code](https://claude.ai/code)