### PR TITLE
Revert "fix(SLB-512): adding prep for ui"

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -28,7 +28,6 @@
     "prep:iframe": "NODE_ENV=production pnpm postcss src/iframe.css -o build/iframe.css",
     "prep:gutenberg": "NODE_ENV=production PREFIX=gutenberg pnpm postcss src/tailwind.css -o build/gutenberg.css",
     "prep:i18n": "formatjs extract 'src/**/*.ts*' --ignore='**/*.d.ts' --ignore='**/*.stories.ts*' --out-file build/translatables.json --id-interpolation-pattern '[sha512:contenthash:base64:6]'\n",
-    "prep": "pnpm prep:types && pnpm prep:scripts && pnpm prep:fonts && pnpm prep:styles && pnpm prep:iframe && pnpm prep:gutenberg && pnpm prep:i18n",
     "build": "storybook build --stats-json",
     "dev": "storybook dev -p 6006 --no-open",
     "start": "serve storybook-static -p 6006 > /dev/null 2>&1",


### PR DESCRIPTION
Turborepo already runs all `prep:*` scripts via it's config: https://github.com/AmazeeLabs/silverback-template/blob/8701d9d95b90533ea0b47a611413dc800edbe977/packages/ui/turbo.json#L53-L63
