### PR TITLE
feat(SLB-468): cardinality validator improvement

### DIFF
--- a/packages/@amazeelabs/silverback-gutenberg/drupal/silverback_gutenberg/src/GutenbergValidation/GutenbergCardinalityValidatorTrait.php
+++ b/packages/@amazeelabs/silverback-gutenberg/drupal/silverback_gutenberg/src/GutenbergValidation/GutenbergCardinalityValidatorTrait.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\silverback_gutenberg\GutenbergValidation;
 
+use Drupal\Component\Utility\Html;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 
 /**
@@ -73,17 +74,26 @@ trait GutenbergCardinalityValidatorTrait {
       return $this->validateEmptyInnerBlocks($expected_children);
     }
 
-    // Count blocks, then check if the quantity for each is correct.
+    // Count blocks and keep references for additional validations.
     $countInnerBlockInstances = [];
+    $innerBlocksByName = [];
     foreach ($block['innerBlocks'] as $innerBlock) {
-      if (!isset($countInnerBlockInstances[$innerBlock['blockName']])) {
-        $countInnerBlockInstances[$innerBlock['blockName']] = 0;
+      $blockName = $innerBlock['blockName'] ?? NULL;
+      if ($blockName === NULL) {
+        continue;
       }
-      $countInnerBlockInstances[$innerBlock['blockName']]++;
+      if (!isset($countInnerBlockInstances[$blockName])) {
+        $countInnerBlockInstances[$blockName] = 0;
+      }
+      $countInnerBlockInstances[$blockName]++;
+      $innerBlocksByName[$blockName][] = $innerBlock;
     }
 
     foreach ($expected_children as $child) {
-      if (!isset($countInnerBlockInstances[$child['blockName']]) && $child['min'] > 0) {
+      $blockName = $child['blockName'];
+      $childBlocks = $innerBlocksByName[$blockName] ?? [];
+
+      if (!isset($countInnerBlockInstances[$blockName]) && $child['min'] > 0) {
         $message = $this->getExpectedQuantityErrorMessage($child);
         return [
           'is_valid' => FALSE,
@@ -91,13 +101,12 @@ trait GutenbergCardinalityValidatorTrait {
         ];
       }
       // Minimum is set to 0, so we don't care if the block is not present.
-      if (!isset($countInnerBlockInstances[$child['blockName']]) && $child['min'] === 0) {
-        return [
-          'is_valid' => TRUE,
-          'message' => '',
-        ];
+      if (!isset($countInnerBlockInstances[$blockName]) && $child['min'] === 0) {
+        continue;
       }
-      if ($countInnerBlockInstances[$child['blockName']] < $child['min']) {
+
+      $blockCount = $countInnerBlockInstances[$blockName] ?? 0;
+      if ($blockCount < $child['min']) {
         return [
           'is_valid' => FALSE,
           'message' => \Drupal::translation()->formatPlural($child['min'],
@@ -109,7 +118,7 @@ trait GutenbergCardinalityValidatorTrait {
             ]),
         ];
       }
-      if ($child['max'] !== GutenbergCardinalityValidatorInterface::CARDINALITY_UNLIMITED && $countInnerBlockInstances[$child['blockName']] > $child['max']) {
+      if ($child['max'] !== GutenbergCardinalityValidatorInterface::CARDINALITY_UNLIMITED && $blockCount > $child['max']) {
         return [
           'is_valid' => FALSE,
           'message' => \Drupal::translation()->formatPlural($child['max'],
@@ -119,6 +128,13 @@ trait GutenbergCardinalityValidatorTrait {
               '%label' => $child['blockLabel'],
               '@max' => $child['max'],
             ]),
+        ];
+      }
+
+      if (!empty($childBlocks) && !$this->hasPopulatedBlock($childBlocks)) {
+        return [
+          'is_valid' => FALSE,
+          'message' => $this->getMissingContentErrorMessage($child),
         ];
       }
     }
@@ -172,7 +188,18 @@ trait GutenbergCardinalityValidatorTrait {
   private function validateAnyInnerBlocks(array $inner_blocks, array $expected_children): array {
     $min = $expected_children['min'];
     $max = $expected_children['max'];
-    $count = count($inner_blocks['innerBlocks']);
+    $innerBlockList = $inner_blocks['innerBlocks'] ?? [];
+    $count = count($innerBlockList);
+    if (
+      $count > 0 &&
+      !$this->hasPopulatedBlock($innerBlockList) &&
+      !$this->isBlockPopulated($inner_blocks)
+    ) {
+      return [
+        'is_valid' => FALSE,
+        'message' => $this->getMissingContentErrorMessage(NULL),
+      ];
+    }
     if ($count < $min) {
       return [
         'is_valid' => FALSE,
@@ -216,6 +243,134 @@ trait GutenbergCardinalityValidatorTrait {
         $messageParams);
     }
     return $result;
+  }
+
+  private function blockHasMeaningfulHtml(array $block): bool {
+    $innerHTML = $block['innerHTML'] ?? '';
+    if (is_string($innerHTML) && $this->stringContainsContent($innerHTML)) {
+      return TRUE;
+    }
+
+    if (!empty($block['innerContent']) && is_array($block['innerContent'])) {
+      foreach ($block['innerContent'] as $chunk) {
+        if (is_string($chunk) && $this->stringContainsContent($chunk)) {
+          return TRUE;
+        }
+      }
+    }
+
+    return FALSE;
+  }
+
+  private function stringContainsContent(string $value): bool {
+    $decoded = Html::decodeEntities($value);
+    $stripped = trim(strip_tags($decoded));
+    if ($stripped !== '') {
+      return TRUE;
+    }
+
+    return (bool) preg_match('/<(img|video|audio|iframe|svg|figure|source|embed|object|picture)\b/i', $value);
+  }
+
+  private function blockHasMeaningfulAttributes(array $block): bool {
+    $attrs = $block['attrs'] ?? [];
+    if (empty($attrs)) {
+      return FALSE;
+    }
+
+    foreach ($attrs as $value) {
+      if ($this->isMeaningfulValue($value)) {
+        return TRUE;
+      }
+    }
+
+    return FALSE;
+  }
+
+  private function isMeaningfulValue(mixed $value): bool {
+    if ($value === NULL) {
+      return FALSE;
+    }
+    if (is_string($value)) {
+      return trim($value) !== '';
+    }
+    if (is_bool($value)) {
+      return $value;
+    }
+    if (is_numeric($value)) {
+      return TRUE;
+    }
+    if (is_array($value)) {
+      foreach ($value as $item) {
+        if ($this->isMeaningfulValue($item)) {
+          return TRUE;
+        }
+      }
+      return FALSE;
+    }
+
+    return TRUE;
+  }
+
+  /**
+   * Checks if any block in the supplied list is populated.
+   */
+  private function hasPopulatedBlock(array $blocks): bool {
+    foreach ($blocks as $block) {
+      if (is_array($block) && $this->isBlockPopulated($block)) {
+        return TRUE;
+      }
+    }
+    return FALSE;
+  }
+
+  private function isBlockPopulated(array $block): bool {
+    $evaluated = FALSE;
+
+    if (array_key_exists('innerHTML', $block) || array_key_exists('innerContent', $block)) {
+      $evaluated = TRUE;
+      if ($this->blockHasMeaningfulHtml($block)) {
+        return TRUE;
+      }
+    }
+
+    if (array_key_exists('attrs', $block)) {
+      $evaluated = TRUE;
+      if ($this->blockHasMeaningfulAttributes($block)) {
+        return TRUE;
+      }
+    }
+
+    if (!empty($block['innerBlocks']) && is_array($block['innerBlocks'])) {
+      $evaluated = TRUE;
+      foreach ($block['innerBlocks'] as $innerBlock) {
+        if (is_array($innerBlock) && $this->isBlockPopulated($innerBlock)) {
+          return TRUE;
+        }
+      }
+    }
+
+    if (!$evaluated) {
+      return TRUE;
+    }
+
+    return FALSE;
+  }
+
+  private function getMissingContentErrorMessage(?array $child_block): string|TranslatableMarkup {
+    $messageSuffix = t('content or attributes.');
+
+    if (!empty($child_block)) {
+      $messageParams = [
+        '%label' => $child_block['blockLabel'],
+        '@message_suffix' => $messageSuffix,
+      ];
+      return t('%label: block must contain @message_suffix', $messageParams);
+    }
+
+    return t('Block must contain @message_suffix', [
+      '@message_suffix' => $messageSuffix,
+    ]);
   }
 
 }

--- a/packages/@amazeelabs/silverback-gutenberg/drupal/silverback_gutenberg/tests/src/Unit/BlockValidatorCardinalityTest.php
+++ b/packages/@amazeelabs/silverback-gutenberg/drupal/silverback_gutenberg/tests/src/Unit/BlockValidatorCardinalityTest.php
@@ -1534,4 +1534,289 @@ class BlockValidatorCardinalityTest extends UnitTestCase {
     );
   }
 
+  public function testRequirePopulatedBlocksWithHtml() {
+    $expectedChildren = [
+      [
+        'blockName' => 'core/paragraph',
+        'blockLabel' => t('Paragraph'),
+        'min' => 1,
+        'max' => GutenbergCardinalityValidatorInterface::CARDINALITY_UNLIMITED,
+      ],
+    ];
+
+    $validBlock = [
+      'blockName' => 'core/column',
+      'innerBlocks' => [
+        [
+          'blockName' => 'core/paragraph',
+          'innerHTML' => '<p>Content</p>',
+          'innerContent' => ['<p>Content</p>'],
+        ],
+      ],
+    ];
+    $invalidBlock = [
+      'blockName' => 'core/column',
+      'innerBlocks' => [
+        [
+          'blockName' => 'core/paragraph',
+          'innerHTML' => '<p></p>',
+          'innerContent' => ['<p></p>'],
+        ],
+      ],
+    ];
+
+    $this->assertEquals(
+      [
+        'is_valid' => TRUE,
+        'message' => '',
+      ],
+      $this->validateCardinality($validBlock, $expectedChildren),
+    );
+    $this->assertEquals(
+      [
+        'is_valid' => FALSE,
+        'message' => '<em class="placeholder">Paragraph</em>: block must contain content or attributes.',
+      ],
+      $this->validateCardinality($invalidBlock, $expectedChildren),
+    );
+  }
+
+  public function testMixedContentBlocksAreValid() {
+    $expectedChildren = [
+      [
+        'blockName' => 'core/paragraph',
+        'blockLabel' => t('Paragraph'),
+        'min' => 1,
+        'max' => 3,
+      ],
+    ];
+
+    $block = [
+      'blockName' => 'core/column',
+      'innerBlocks' => [
+        [
+          'blockName' => 'core/paragraph',
+          'innerHTML' => '<p></p>',
+          'innerContent' => ['<p></p>'],
+        ],
+        [
+          'blockName' => 'core/paragraph',
+          'innerHTML' => '<p>Content</p>',
+          'innerContent' => ['<p>Content</p>'],
+        ],
+      ],
+    ];
+
+    $this->assertEquals(
+      [
+        'is_valid' => TRUE,
+        'message' => '',
+      ],
+      $this->validateCardinality($block, $expectedChildren),
+    );
+  }
+
+  public function testRequirePopulatedBlocksWithAttributes() {
+    $expectedChildren = [
+      [
+        'blockName' => 'core/embed',
+        'blockLabel' => t('Embed'),
+        'min' => 1,
+        'max' => 1,
+      ],
+    ];
+
+    $validBlock = [
+      'blockName' => 'core/column',
+      'innerBlocks' => [
+        [
+          'blockName' => 'core/embed',
+          'innerHTML' => '',
+          'innerContent' => [],
+          'attrs' => [
+            'url' => 'https://example.com/video',
+          ],
+        ],
+      ],
+    ];
+    $invalidBlock = [
+      'blockName' => 'core/column',
+      'innerBlocks' => [
+        [
+          'blockName' => 'core/embed',
+          'innerHTML' => '',
+          'innerContent' => [],
+          'attrs' => [],
+        ],
+      ],
+    ];
+
+    $this->assertEquals(
+      [
+        'is_valid' => TRUE,
+        'message' => '',
+      ],
+      $this->validateCardinality($validBlock, $expectedChildren),
+    );
+    $this->assertEquals(
+      [
+        'is_valid' => FALSE,
+        'message' => '<em class="placeholder">Embed</em>: block must contain content or attributes.',
+      ],
+      $this->validateCardinality($invalidBlock, $expectedChildren),
+    );
+  }
+
+  public function testAnyBlockTypeRequiresContent() {
+    $expectedChildren = [
+      'validationType' => GutenbergCardinalityValidatorInterface::CARDINALITY_ANY,
+      'min' => 1,
+      'max' => 2,
+    ];
+
+    $validBlock = [
+      'blockName' => 'core/group',
+      'innerBlocks' => [
+        [
+          'blockName' => 'core/paragraph',
+          'innerHTML' => '<p>Content</p>',
+          'innerContent' => ['<p>Content</p>'],
+        ],
+      ],
+    ];
+    $invalidBlock = [
+      'blockName' => 'core/group',
+      'innerBlocks' => [
+        [
+          'blockName' => 'core/paragraph',
+          'innerHTML' => '<p></p>',
+          'innerContent' => ['<p></p>'],
+        ],
+      ],
+    ];
+
+    $this->assertEquals(
+      [
+        'is_valid' => TRUE,
+        'message' => '',
+      ],
+      $this->validateCardinality($validBlock, $expectedChildren),
+    );
+    $this->assertEquals(
+      [
+        'is_valid' => FALSE,
+        'message' => 'Block must contain content or attributes.',
+      ],
+      $this->validateCardinality($invalidBlock, $expectedChildren),
+    );
+    $this->assertEquals(
+      [
+        'is_valid' => FALSE,
+        'message' => 'At least 1 block is required.',
+      ],
+      $this->validateCardinality([
+        'blockName' => 'core/group',
+        'innerBlocks' => [],
+      ], $expectedChildren),
+    );
+  }
+
+  public function testAnyBlockTypeAcceptsNestedContent() {
+    $expectedChildren = [
+      'validationType' => GutenbergCardinalityValidatorInterface::CARDINALITY_ANY,
+      'min' => 1,
+      'max' => 2,
+    ];
+
+    $block = [
+      'blockName' => 'core/group',
+      'innerBlocks' => [
+        [
+          'blockName' => 'custom/accordion-item-text',
+          'innerHTML' => '',
+          'innerContent' => [],
+          'innerBlocks' => [
+            [
+              'blockName' => 'core/paragraph',
+              'innerHTML' => '<p>Content</p>',
+              'innerContent' => ['<p>Content</p>'],
+            ],
+          ],
+        ],
+      ],
+    ];
+
+    $this->assertEquals(
+      [
+        'is_valid' => TRUE,
+        'message' => '',
+      ],
+      $this->validateCardinality($block, $expectedChildren),
+    );
+  }
+
+  public function testBlockWithOnlyNestedContentSucceedsWhenDescendantHasContent() {
+    $expectedChildren = [
+      [
+        'blockName' => 'custom/accordion-item-text',
+        'blockLabel' => t('Accordion item'),
+        'min' => 1,
+        'max' => 1,
+      ],
+    ];
+
+    $validBlock = [
+      'blockName' => 'custom/accordion',
+      'innerBlocks' => [
+        [
+          'blockName' => 'custom/accordion-item-text',
+          'innerHTML' => '',
+          'innerContent' => [],
+          'attrs' => [],
+          'innerBlocks' => [
+            [
+              'blockName' => 'core/paragraph',
+              'innerHTML' => '<p>Some content</p>',
+              'innerContent' => ['<p>Some content</p>'],
+            ],
+          ],
+        ],
+      ],
+    ];
+
+    $invalidBlock = [
+      'blockName' => 'custom/accordion',
+      'innerBlocks' => [
+        [
+          'blockName' => 'custom/accordion-item-text',
+          'innerHTML' => '',
+          'innerContent' => [],
+          'attrs' => [],
+          'innerBlocks' => [
+            [
+              'blockName' => 'core/paragraph',
+              'innerHTML' => '<p></p>',
+              'innerContent' => ['<p></p>'],
+            ],
+          ],
+        ],
+      ],
+    ];
+
+    $this->assertEquals(
+      [
+        'is_valid' => TRUE,
+        'message' => '',
+      ],
+      $this->validateCardinality($validBlock, $expectedChildren),
+    );
+    $this->assertEquals(
+      [
+        'is_valid' => FALSE,
+        'message' => '<em class="placeholder">Accordion item</em>: block must contain content or attributes.',
+      ],
+      $this->validateCardinality($invalidBlock, $expectedChildren),
+    );
+  }
+
 }

--- a/packages/drupal/gutenberg_blocks/src/Plugin/Validation/GutenbergValidator/InfoGridValidator.php
+++ b/packages/drupal/gutenberg_blocks/src/Plugin/Validation/GutenbergValidator/InfoGridValidator.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Drupal\gutenberg_blocks\Plugin\Validation\GutenbergValidator;
+
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\silverback_gutenberg\GutenbergValidation\GutenbergCardinalityValidatorInterface;
+use Drupal\silverback_gutenberg\GutenbergValidation\GutenbergCardinalityValidatorTrait;
+use Drupal\silverback_gutenberg\GutenbergValidation\GutenbergValidatorBase;
+
+/**
+ * @GutenbergValidator(
+ *   id="info_grid_validator",
+ *   label = @Translation("Info Grid validator")
+ * )
+ */
+class InfoGridValidator extends GutenbergValidatorBase {
+  use GutenbergCardinalityValidatorTrait;
+  use StringTranslationTrait;
+
+  /**
+   * {@inheritDoc}
+   */
+  public function applies(array $block): bool {
+    return $block['blockName'] === 'custom/info-grid';
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function validateContent($block = []): array {
+    $expectedChildren = [
+      [
+        'blockName' => 'custom/info-grid-item',
+        'blockLabel' => $this->t('Info Grid Item'),
+        'min' => 1,
+        'max' => GutenbergCardinalityValidatorInterface::CARDINALITY_UNLIMITED,
+      ],
+    ];
+    return $this->validateCardinality($block, $expectedChildren);
+  }
+
+}


### PR DESCRIPTION
## Description of changes
Extend the cardinality validator to ensure content of children blocks is checked, not just the count.  The cardinality validator now ensures at least one counted child (or any descendant) must expose meaningful content (non-empty HTML or attributes). The rest of any validation would be left to block-specific validation, like using the required validator.