### PR TITLE
Fix shared preview authentication

### DIFF
--- a/apps/preview/src/drupal-executor.ts
+++ b/apps/preview/src/drupal-executor.ts
@@ -47,7 +47,9 @@ export function drupalExecutor(
       }
       const { data, errors } = await (
         await fetch(url, {
-          credentials: 'include',
+          // When using a preview access token, omit cookies to prevent
+          // Drupal's cookie auth provider from overriding token auth.
+          credentials: preview_access_token ? 'omit' : 'include',
           headers: forward
             ? {
                 'SLB-Forwarded-Proto': window.location.protocol.slice(0, -1),

--- a/packages/@amazeelabs/silverback-gatsby/drupal/silverback_gatsby/src/Plugin/GraphQL/DataProducer/FetchEntity.php
+++ b/packages/@amazeelabs/silverback-gatsby/drupal/silverback_gatsby/src/Plugin/GraphQL/DataProducer/FetchEntity.php
@@ -356,6 +356,16 @@ class FetchEntity extends DataProducerPluginBase implements ContainerFactoryPlug
               'body',
             ]) || str_starts_with($name, 'field_')) {
               if (isset($current_user_input[$name])) {
+                // Skip entity reference fields: raw widget input is an
+                // autocomplete string (e.g. "Title (42)") which corrupts
+                // setValue(). The autosaved entity already has correct values.
+                if (in_array($field->getFieldDefinition()->getType(), [
+                  'entity_reference',
+                  'entity_reference_revisions',
+                  'dynamic_entity_reference',
+                ])) {
+                  continue;
+                }
                 $field->setValue($current_user_input[$name]);
               }
             }

--- a/packages/@amazeelabs/silverback-gatsby/drupal/silverback_gatsby/tests/src/Kernel/FetchEntityAutosaveTest.php
+++ b/packages/@amazeelabs/silverback-gatsby/drupal/silverback_gatsby/tests/src/Kernel/FetchEntityAutosaveTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Drupal\Tests\silverback_gatsby\Kernel;
+
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\node\Entity\Node;
+
+class FetchEntityAutosaveTest extends EntityFeedTestBase {
+
+  protected function setUp(): void {
+    parent::setUp();
+    // Enable after parent::setUp() to avoid hook errors during user creation.
+    $this->enableModules(['silverback_autosave']);
+    $this->installSchema('silverback_autosave', ['silverback_autosave_entity_form']);
+
+    FieldStorageConfig::create([
+      'field_name' => 'field_reference',
+      'entity_type' => 'node',
+      'type' => 'entity_reference',
+      'settings' => [
+        'target_type' => 'node',
+      ],
+    ])->save();
+
+    FieldConfig::create([
+      'field_name' => 'field_reference',
+      'entity_type' => 'node',
+      'bundle' => 'page',
+      'label' => 'Reference',
+    ])->save();
+  }
+
+  public function testAutosaveSkipsEntityReferenceFields(): void {
+    $referencedNode = Node::create([
+      'type' => 'blog',
+      'title' => 'Referenced Node',
+      'status' => 1,
+    ]);
+    $referencedNode->save();
+
+    $node = Node::create([
+      'type' => 'page',
+      'title' => 'Original Title',
+      'body' => [['value' => 'Original body']],
+      'field_reference' => [['target_id' => $referencedNode->id()]],
+      'status' => 1,
+    ]);
+    $node->save();
+
+    $this->storeAutosave($node, [
+      'title' => [['value' => 'Autosaved Title']],
+      'body' => [['value' => 'Autosaved body']],
+      'field_reference' => [['target_id' => "Referenced Node ({$referencedNode->id()})"]],
+    ]);
+
+    $result = $this->executeDataProducer('fetch_entity', [
+      'type' => 'node',
+      'id' => (string) $node->id(),
+      'bundles' => ['page'],
+      'access' => FALSE,
+    ]);
+
+    $this->assertNotNull($result);
+    $this->assertEquals('Autosaved Title', $result->getTitle());
+    $this->assertEquals('Autosaved body', $result->get('body')->value);
+    $this->assertEquals(
+      $referencedNode->id(),
+      $result->get('field_reference')->target_id,
+      'Entity reference field should retain its original target_id, not be corrupted by autocomplete string input.',
+    );
+  }
+
+  private function storeAutosave(Node $node, array $userInput): void {
+    $serializer = \Drupal::service('serialization.phpserialize');
+    $currentUserId = \Drupal::currentUser()->id();
+    \Drupal::database()->insert('silverback_autosave_entity_form')
+      ->fields([
+        'form_id' => "node_{$node->bundle()}_edit_form",
+        'form_session_id' => 'test-session',
+        'entity_type_id' => 'node',
+        'entity_id' => $node->id(),
+        'langcode' => $node->language()->getId(),
+        'uid' => $currentUserId,
+        'timestamp' => time(),
+        'entity' => $serializer->encode(Node::load($node->id())),
+        'form_state' => $serializer->encode([
+          'storage' => [],
+          'input' => $userInput,
+        ]),
+      ])
+      ->execute();
+  }
+
+}


### PR DESCRIPTION
Fixes two issues that break the "Share preview" flow:

1. Preview app sends cookies alongside preview_access_token, causing cookie auth to override token auth on subsequent requests
2. FetchEntity data producer corrupts entity reference fields during autosave setValue, triggering PHP warnings that create unwanted sessions